### PR TITLE
Having DDG results display on the right of search results

### DIFF
--- a/js/google.js
+++ b/js/google.js
@@ -37,7 +37,7 @@ chrome.extension.sendMessage({options: "get"}, function(opt){
                 inputName: 'q',
                 forbiddenIDs: ['rg_s'],
                 hover: true,
-                contentDiv: 'center_col',
+                contentDiv: 'rhs',
                 className: 'google',
                 debug: options.dev
               });


### PR DESCRIPTION
This simple change makes the DDG extension much better (in my opinion) when displaying results!
First: the DDG result appears on the right-hand side, not pushing the actual Google link down, and still providing useful information:
![](http://i.imgur.com/pSd2tvN.png)

In addition, things like `regex` results also don't block the actual search results, and look great on widescreens:
![](http://i.imgur.com/XD6ziLp.png)
