### PR TITLE
fix: Make safesearch default to true

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -89,7 +89,7 @@ function restore_options() {
   }
 
   var safesearch = localStorage["safesearch"];
-  if (safesearch === 'true') {
+  if (safesearch === 'true' || safesearch == undefined) {
     document.getElementById("safesearch").checked = true;
   } else {
     document.getElementById("safesearch").checked = false;


### PR DESCRIPTION
* This commit makes sure that the safesearch option defaults to true in
  the options page.

Signed-off-by: mr.Shu <mr@shu.io>