### PR TITLE
update: Make DuckDuckGo the default on Windows

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -48,5 +48,5 @@
       "16": "img/icon_16.png",
       "48": "img/icon_48.png"
    },
-	"permissions": [ "contextMenus", "unlimitedStorage", "http://*/*", "https://*/*", "cookies", "tabs" ]
+	"permissions": [ "contextMenus", "unlimitedStorage", "http://*/*", "https://*/*", "tabs" ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -42,11 +42,5 @@
       },
 	  "startup_pages": ["https://duckduckgo.com"]
    },
-   "description": "Search the Web Privately with DuckDuckGo",
-   "icons": {
-      "128": "img/icon_128.png",
-      "16": "img/icon_16.png",
-      "48": "img/icon_48.png"
-   },
-	"permissions": [ "contextMenus", "unlimitedStorage", "http://*/*", "https://*/*", "tabs" ]
+   "description": "Search the Web Privately with DuckDuckGo"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,18 @@
     "background": {
             "scripts": ["js/background.js"]
     },
+    "chrome_settings_overrides": {
+      "homepage": "https://www.duckduckgo.com",
+      "search_provider": {
+          "name": "DuckDuckGo",
+          "keyword": "ddg",
+          "search_url": "https://duckduckgo.com/?q={searchTerms}",
+          "encoding": "UTF-8",
+          "is_default": true
+      },
+      "startup_pages": ["https://duckduckgo.com"]
+    },
     "permissions": [
-        "contextMenus"
+      "contextMenus"
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -42,5 +42,7 @@
       },
 	  "startup_pages": ["https://duckduckgo.com"]
    },
-   "description": "Search the Web Privately with DuckDuckGo"
+   "permissions": [
+     "contextMenus"
+   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -25,23 +25,28 @@
         }
       }
     },
-    "omnibox": {"keyword": "d"},
+    "omnibox": {"keyword": "ddg"},
     "options_page": "html/options.html",
     "background": {
             "scripts": ["js/background.js"]
     },
     "chrome_settings_overrides": {
-      "homepage": "https://www.duckduckgo.com",
       "search_provider": {
-          "name": "DuckDuckGo",
-          "keyword": "ddg",
-          "search_url": "https://duckduckgo.com/?q={searchTerms}",
-          "encoding": "UTF-8",
-          "is_default": true
+		 "homepage": "http://www.duckduckgo.com",
+         "encoding": "UTF-8",
+         "favicon_url": "https://duckduckgo.com/favicon.ico",
+         "is_default": true,
+         "keyword": "duckduckgo.com",
+         "name": "DDG Search",
+         "search_url": "https://duckduckgo.com/?q={searchTerms}"
       },
-      "startup_pages": ["https://duckduckgo.com"]
-    },
-    "permissions": [
-      "contextMenus"
-    ]
+	  "startup_pages": ["https://duckduckgo.com"]
+   },
+   "description": "Search the Web Privately with DuckDuckGo",
+   "icons": {
+      "128": "img/icon_128.png",
+      "16": "img/icon_16.png",
+      "48": "img/icon_48.png"
+   },
+	"permissions": [ "contextMenus", "unlimitedStorage", "http://*/*", "https://*/*", "cookies", "tabs" ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -32,17 +32,15 @@
     },
     "chrome_settings_overrides": {
       "search_provider": {
-		 "homepage": "http://www.duckduckgo.com",
-         "encoding": "UTF-8",
-         "favicon_url": "https://duckduckgo.com/favicon.ico",
-         "is_default": true,
-         "keyword": "duckduckgo.com",
-         "name": "DDG Search",
-         "search_url": "https://duckduckgo.com/?q={searchTerms}"
-      },
-	  "startup_pages": ["https://duckduckgo.com"]
-   },
-   "permissions": [
-     "contextMenus"
-   ]
+        "encoding": "UTF-8",
+        "favicon_url": "https://duckduckgo.com/favicon.ico",
+        "is_default": true,
+        "keyword": "duckduckgo.com",
+        "name": "DuckDuckGo Search",
+        "search_url": "https://duckduckgo.com/?q={searchTerms}"
+      }
+    },
+    "permissions": [
+      "contextMenus"
+    ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
         }
       }
     },
-    "omnibox": {"keyword": "ddg"},
+    "omnibox": {"keyword": "d"},
     "options_page": "html/options.html",
     "background": {
             "scripts": ["js/background.js"]


### PR DESCRIPTION
* Add parameters to manifest.json to make DuckDuckGo the default search
  engine on Windows.

Signed-off-by: mr.Shu <mr@shu.io>

-------------------

to @AdamSC1-ddg 