### PR TITLE
add: ATB param, no ATB CSS file

### DIFF
--- a/css/noatb.css
+++ b/css/noatb.css
@@ -1,0 +1,3 @@
+.ddg-extension-hide {
+        display: none !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,16 @@
     "background": {
             "scripts": ["js/background.js"]
     },
+    "content_scripts": [
+      {
+        "matches": ["https://*.duckduckgo.com/*", "https://duckduckgo.com/*"],
+        "css": ["css/noatb.css"]
+      }
+    ],
     "permissions": [
-        "contextMenus"
+        "contextMenus",
+        "webRequest",
+        "webRequestBlocking",
+        "*://duckduckgo.com/"
     ]
 }


### PR DESCRIPTION
* Add ATB param to requests going to DuckDuckGo.com

* Add a CSS file that hides ATB popups on DuckDuckGo.com

Signed-off-by: mr.Shu <mr@shu.io>