### PR TITLE
update: Get the ATB param from opened site

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -53,6 +53,9 @@ function Background() {
         chrome.tabs.executeScript(tab.id, {
           file: 'js/oninstall.js'
         });
+        chrome.tabs.insertCSS(tab.id, {
+          file: 'css/noatb.css'
+        });
       }
     });
   });

--- a/js/background.js
+++ b/js/background.js
@@ -125,6 +125,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     {
         urls: [
             "*://duckduckgo.com/?*",
+            "*://*.duckduckgo.com/?*",
         ],
         types: ["main_frame"]
     },

--- a/js/oninstall.js
+++ b/js/oninstall.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2012, 2016 DuckDuckGo, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var atbParam = document.querySelector('html').getAttribute('data-atb');
+chrome.extension.sendMessage({atb: atbParam});

--- a/manifest.json
+++ b/manifest.json
@@ -33,13 +33,14 @@
     "content_scripts": [
       {
         "matches": ["https://*.duckduckgo.com/*", "https://duckduckgo.com/*"],
-        "css": ["css/noatb.css"]
+        "css": ["css/noatb.css"],
+        "js": ["js/oninstall.js"]
       }
     ],
     "permissions": [
         "contextMenus",
         "webRequest",
         "webRequestBlocking",
-        "*://duckduckgo.com/"
+        "*://*.duckduckgo.com/"
     ]
 }


### PR DESCRIPTION
* Get the ATB param from loaded DuckDuckGo.com site which presumably
  initiated the install procedure.

* Make sure that the ATB param is only set on install.

Signed-off-by: mr.Shu <mr@shu.io>