### PR TITLE
fix: Do not run oninstall on every load

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,8 +43,7 @@
     "content_scripts": [
       {
         "matches": ["https://*.duckduckgo.com/*", "https://duckduckgo.com/*"],
-        "css": ["css/noatb.css"],
-        "js": ["js/oninstall.js"]
+        "css": ["css/noatb.css"]
       }
     ],
     "permissions": [


### PR DESCRIPTION
* Only run oninstall.js when the extension is being installed.

Signed-off-by: mr.Shu <mr@shu.io>