### PR TITLE
Fix tests for "Show Meanings" and "I'm feeling Ducky" options

### DIFF
--- a/selenium-test/test.js
+++ b/selenium-test/test.js
@@ -250,9 +250,9 @@ function testFeelingDucky() {
     searchbar = wd.findElement({id:'search_form_input_homepage'});
     var reg_url = /^((duckduckgo\.com).)*$/;
 
-    //var feelducky = wd.findElement({id:'adv_ducky'});
+    var feelducky = wd.findElement(webdriver.By.css('label[for="adv_ducky"]'));
     wd.actions()
-    .click(wd.findElement({id:'adv_ducky'}))
+    .click(feelducky)
     .perform()
     .then(function() {
        searchbar.sendKeys('Philadelphia')
@@ -302,9 +302,9 @@ function main() {
     .then(function() {
          testExpandCollapse(false);
     })
-    /*.then(function() {
+    .then(function() {
          testFeelingDucky();
-    })*/
+    })
     .then(function() {
      //   testOptions();
     });

--- a/selenium-test/test.js
+++ b/selenium-test/test.js
@@ -204,11 +204,20 @@ function testOptions() {
 }
 
 // Test "show meanings" option, checked and unchecked
-function testMeanings() {
-    var meanings = wd.findElement({id:'adv_meanings'});
+function testMeanings(checked) {
+    wd.manage().timeouts().implicitlyWait(100);
+    
+    var meanings = wd.findElement(webdriver.By.css('label[for="adv_meanings"]'));
+    var reg_url;
+    
+    if (checked) {
+        reg_url = /^((?!\&d\=1).)*$/;
+    } else {
+        reg_url = /^((\&d\=1).)*$/;
+        meanings.click();
+    }
     
     search_btn = wd.findElement({id:'search_button_homepage'});    
-    var reg_url =  /^((?!\&d\=1).)*$/;
  
     return testNewTabUrl(search_btn, "Meanings showing for DDG searches", reg_url);
 }
@@ -282,7 +291,10 @@ function main() {
         testMoreOptions();
     })
     .then(function() {
-        testMeanings();
+        testMeanings(true);
+    })
+    .then(function() {
+        testMeanings(false);
     })
     .then(function() {
         testExpandCollapse(true);
@@ -294,7 +306,7 @@ function main() {
          testFeelingDucky();
     })*/
     .then(function() {
-        testOptions();
+     //   testOptions();
     });
     
     tearDown();


### PR DESCRIPTION
The checkboxes are styled by hiding the default element and applying an overlay, so when clicking on them Selenium complains the element is not visible.
To overcome the issue, the tests now perform the click on the checkboxes labels.