### PR TITLE
Add jshint testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pem
+jshint_log.txt

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "undef": true,
+  "unused": true,
+  "curly": true,
+  "eqeqeq": true
+}

--- a/package.json
+++ b/package.json
@@ -6,11 +6,15 @@
   },
   "repository": "duckduckgo/chrome-zeroclickinfo",
   "scripts": {
-    "postinstall" : "export PATH='$PATH:$PWD/node_modules/chromedriver/bin'",
-    "test": "cd selenium-test && node test.js"
+    "postinstall": "export PATH='$PATH:$PWD/node_modules/chromedriver/bin'",
+    "test": "concurrently 'npm run jshint' 'npm run selenium'",
+    "selenium": "cd selenium-test && node test.js",
+    "jshint": "jshint js/ --verbose > jshint_log.txt"
   },
   "devDependencies": {
     "chromedriver": "^2.27.2",
+    "concurrently": "^3.1.0",
+    "jshint": "^2.9.4",
     "localStorage": "^1.0.3",
     "selenium-webdriver": "^3.0.1"
   }


### PR DESCRIPTION
Adding [jshint](http://jshint.com/about/) to `npm test`, in order to detect JS errors.
The test runs concurrently with the Selenium ones, using another nodejs module, so that if either test script fails, the other one will still run.

Test results for jshint are saved into a log file, jshint_log.txt.