### PR TITLE
Instant search suggestions

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -93,6 +93,23 @@ function Background() {
 
 var background = new Background();
 
+let tabCallbacks = {};
+
+// Since callbacks specified as the third argument of chrome.tabs.update calls
+// unfortunately fire prematurely, during the 'loading' phase of the tab update,
+// a collection of tab update callbacks is maintained here per tab ID, fired
+// only once the update is indeed 'complete'.
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status !== 'complete') {
+    return;
+  }
+
+  if (tabCallbacks[tabId]) {
+    tabCallbacks[tabId]();
+    delete tabCallbacks[tabId];
+  }
+});
+
 // Fetch and display search suggestions
 chrome.omnibox.onInputChanged.addListener((text, suggest) => {
   function escapeXML(string) {
@@ -141,11 +158,22 @@ chrome.omnibox.onInputChanged.addListener((text, suggest) => {
 
 chrome.omnibox.onInputEntered.addListener(function(text) {
   chrome.tabs.query({
-    'currentWindow': true,
-    'active': true
-  }, function(tabs) {
-    chrome.tabs.update(tabs[0].id, {
-      url: "https://duckduckgo.com/?q=" + encodeURIComponent(text) + "&bext=" + localStorage['os'] + "cl"
+    currentWindow: true,
+    active: true
+  }, (tabs) => {
+    const tabId = tabs[0].id;
+
+    // Register a callback for the 'complete' state of the tab update
+    tabCallbacks[tabId] = function () {
+      chrome.tabs.executeScript({
+        file: 'js/onsearch.js',
+        runAt: 'document_end'
+      });
+    };
+
+    // Display search results
+    chrome.tabs.update(tabId, {
+      url: `https://duckduckgo.com/?q=${encodeURIComponent(text)}&bext=${localStorage['os']}cl`
     });
   });
 });

--- a/js/onsearch.js
+++ b/js/onsearch.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2012, 2016 DuckDuckGo, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * On tabs programmatically updated with chrome.tabs.update as a result of some
+ * user input into the omnibox, the focus stays on the omnibox even when the
+ * content of the tab has been fully loaded. This is unintuitive behavior, as
+ * on any other omnibox interaction the omnibox would lose focus once the
+ * requested page is loaded. Unfortunately, Chrome doesn't offer any solutions
+ * to this problem, other than the very clumsy creation of a new tab and
+ * removal of the current one in rapid succession, which would also result in
+ * losing the opener tab's history. To add fuel to the fire, tabbing out of the
+ * omnibox brings focus to the search input field, which is not the desired
+ * user experience on the result page as it blocks keyboard navigation through
+ * the search results.
+ *
+ * To mitigate the problem, this content script gets injected on every search
+ * initiated from the extension, and shifts any explicitly specified positive
+ * tabindices by one, giving the tabindex "1" to the body, where the focus
+ * would normally be having searched through the DuckDuckGo UI. This way, while
+ * the updated tab's focus remains on the omnibox nonetheless, at least hitting
+ * the Tab key once will bring keyboard navigation through the results within
+ * reasonable reach.
+ */
+
+document.querySelectorAll('[tabindex]').forEach((element) => {
+  if (element.tabIndex > 0) {
+    element.tabIndex = element.tabIndex + 1;
+  }
+});
+
+document.body.tabIndex = 1;

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
         "favicon_url": "https://duckduckgo.com/favicon.ico",
         "is_default": true,
         "keyword": "duckduckgo.com",
-        "name": "DuckDuckGo Search",
+        "name": "DuckDuckGo",
         "search_url": "https://duckduckgo.com/?q={searchTerms}"
       }
     },

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "DuckDuckGo for Chrome",
+    "name": "DuckDuckGo",
     "version": "42.7.8",
     "description": "DuckDuckGo enhancements for Chrome.",
     "icons": {


### PR DESCRIPTION
This changeset implements instant search suggestions per #32.

To receive suggestions, the user has to explicitly type the extension's keyword first (currently `d`), and hit space. If the `d` keyword is already defined in the browser as another search provider's keyword, the omnibox will not enter "extension mode". The implementation emulates Chrome's inverse suggestion highlighting style (the **suggested** part is bold), and handles *!bangs*.

![](https://www.evernote.com/shard/s381/sh/0eaca012-453c-4cff-86cc-4c6e35d037e4/47b2f2a03bcccaa633d253917ca37c7e/res/08f57587-ab80-48cc-b0bd-05ddbb544a58/skitch.png)
---
![](https://www.evernote.com/shard/s381/sh/ded97e72-b5a3-4716-92ad-359b4e1f7785/c672ebeb1e761a23b3c4a8e94972ba6f/res/e95540d4-b3a3-435d-bad1-4128f58f70cc/skitch.png)

It would be desirable for the omnibox to display instant suggestions as soon as the user types something into the naked omnibox, but currently this is not doable. While the [`manifest.json` documentation](https://developer.chrome.com/extensions/manifest) specifies an optional `instant_url` key for the `search_provider`, it is not documented how this should work or what format Chrome expects the suggestions to arrive in, and is probably not even implemented, much like the related [`search_url_post_params`](http://stackoverflow.com/a/41968262).
