### PR TITLE
[POC] Replace social widgets

### DIFF
--- a/html/intro.html
+++ b/html/intro.html
@@ -20,6 +20,7 @@
     <ul>
         <li>Encryption - using HTTPS Everywhere</li>
         <li>Tracker Blocking - using the Firefox/Disconnect tracker list</li>
+        <li>Social Blocking: blocks social requests and replaces Facebook and Twitter buttons - using the PrivacyBadger social widgets list and assets</li>
     </ul>
 
     <p>

--- a/html/popup.html
+++ b/html/popup.html
@@ -48,6 +48,12 @@
             Enable privacy features
         </label>
       </li>
+      <li class="hide">
+        <input type="checkbox" id="toggle_social_blocking">
+        <label for="toggle_social_blocking">
+            Block social widgets
+        </label>
+      </li>
       <li>
         <input type="checkbox" id="adv_ducky">
         <label for="adv_ducky">

--- a/img/FacebookLike.svg
+++ b/img/FacebookLike.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64.607384"
+   height="31.538702"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Facebook.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.03"
+     inkscape:cx="25.018943"
+     inkscape:cy="27.000707"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1222"
+     inkscape:window-height="1419"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="0">
+    <sodipodi:guide
+       position="53.472539,0.8733177"
+       orientation="0,53.46875"
+       id="guide3203" />
+    <sodipodi:guide
+       position="64.675443,34.289776"
+       orientation="-24,0"
+       id="guide3205" />
+    <sodipodi:guide
+       position="53.472539,31.62976"
+       orientation="0,-53.46875"
+       id="guide3207" />
+    <sodipodi:guide
+       position="0.00378865,31.523359"
+       orientation="24,0"
+       id="guide3209" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-0.62121135,-8.4846564)">
+    <rect
+       style="fill:#f0f0f0;fill-opacity:1;stroke:#d7d7d7;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect2985"
+       width="52.482887"
+       height="23"
+       x="1.1212113"
+       y="8.9846563"
+       ry="2.1487894"
+       rx="2.1487894" />
+    <text
+       xml:space="preserve"
+       style="font-size:14.40710354px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#535353;fill-opacity:1;stroke:none;font-family:Sans"
+       x="25.624592"
+       y="24.967773"
+       id="text4002"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4004"
+         x="25.624592"
+         y="24.967773"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#535353;fill-opacity:1;font-family:Tahoma;-inkscape-font-specification:Tahoma">Like</tspan></text>
+    <image
+       y="21.60157"
+       x="46.806808"
+       id="image3042"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKoAAACqCAYAAAA9dtSCAAAABHNCSVQICAgIfAhkiAAAIABJREFU eJztnXl4E9Xex7+zJE2TbqQLBGiBIrQFikUWsSxWKSIoFMSFRa6yiYoXFMUFxKuooKIICq8ioiJC uQIioCDWAlcB2ZRVoBVQCrR0oXRvtpnz/pFm2mmWJmmWUefzPHkeOJmZnGS+PXPObzuAjIyMjIyM jIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjJehAt0BV+DLLhPjyqGAWR/orvx9YFVQTt0BOqLt X0IDdKA74Arm3W/JIvU2Zr3ld/2LIHmhcnmHCH92R6C78beEP7sDXN4hEuh+uAIb6A44g+fMxPTp yEB342+N+fv54DkzoRlW0lMAaQv12HqQ4hxRG7uxEMxvVQHq0V8frmsIzPe2FP5PinPAH1sfwB65 hmSFSmrLiHHFYFEbdVkP5peKAPXo7wHzSwW4vuEgbVVCG/fTUpDaMkIFR0h2VJXsHNX803sgtWWi NnZbcYB68/ei8e9Iastg/um9APXGNSQpVL44l3C/rhO1MYfKQefJK39vQOfpwRwqF7Vxv64DX5wr 2YWVJIVq/n4+QLj6BgMPJuta4Dr0N4TJugYY+PoGwll+d4kiOaFyOTsJn3dQ1MZmXQNVxTk4Q8YT qCoObKM/fj7vILicnZIcVSUlVGKqJebsN0RtVJERzIFyB2fINAfmQDmoIqOozZz9BoipVnJilZRQ uUOfgJRfFrWxO0oATnK/298Djlh+3waQ8svgDn0SoA45RjJC5csuE/P+D0VtdG4N6LPVAerRPwP6 bDXo3BpRm3n/h+DLLktqdJCMUG38+RyRzVF+gt1WLH5qSTAOQBJCtefPZ/aXgSoxOjhDxptQJUYw +8U2a6nFAQRcqDxnJo3NIlQVB3ZXaYB69M+E3VVqY1mxxgEEqEsiAi9UO/585rsSQM87OEPGJ+h5 y+/eACnFAQRUqKS2jHA/LRW1yf78wMH8UgHqstj7Z40DCFCXBAIqVNmfLz2kGgcQMKHa9ecfrZT9 +QGGztODOVopapNCHEDAhGrXn79dHk2lALO9WHJxAAERquzPlzZSjAPwu1Blf/5fA6nFAfhdqLI/ /y+CxOIA/CpU2Z//10JKcQB+Farsz//rIZU4AL8l93F5h4hp7XhRmxT8+SRKCT5BDb59MEgEC6gZ yxtmAqrMDPpiLegz1aAKDAHtZ6CwxgFwA1oIbdY4ACauj9+SAf0iVMJzxPhJhqgt0P58PlED8yCt KBuzMSRGCb6zGhgcCeqyHmx26T9ymsLuKgXfIwwkhBHazN/PB+E5QtGMX8TqF6FyRzOl489X0TCN bgm+W4ioOafYiFNXjSip5lBt5BGtYZAQo0SP1kFQMBRIWxVMD7UGc6gc7Nbif9biry4OoHE9AO5o pt+64HOhSik/n4SzME1qAxKjBAAUVXH48OcyfHigAqU1ZrvnaNUsxqaE4LnbtIgJYcD1CQeJUEDx ef4/SqyBrgfg88WUZPz5Klok0jW/VKDzW39iwa5ShyIFgNIaM5bvL0PKu3nIPmdZAfOd1TCNaeWX bkuJQMYB+FSoUvLnm4dGCSJd/ON1TN1YCL3J9alHaY0Zd626gk0nLeWE+G4h4PpF+KSvUiWQcQA+ ffRLxZ9PdEHg+oQDADadrMKcRoZsd5i8oRDdWimREK2EeXAk6OOV0nX9MhT4NkEgsSqQcBYIYUEU FCgTAUw8qCIjqGsmUJf1Ln8HZnsxuC4aIKhujPNTHIDPhMrl7CSmr54Qf1iA/PlcX4tITRzBC99d b9a19CYes7YV49tJbYAgGtzAFmC3ey58X8AnasD1DAOfoAEUrk0fqct6MGeqLSkpTha51jgA893R 9Z9XFwfAJAzx2VzVJ0IlplpiXDlM1EaVmgLmz+e7WFb4W09XI6/U8bRDq2YRomJRVGl0Oi3I/r0G 2edqMOgGNfgeYYBEhEp0QTDdE2PX5FZUxeF6LYdyPQ+1gkKYioEulIGizrpE2qpgbquCOU0Ldk8p mP9dd7hYZA6Ug0uNANEqhDZrHAClCPaJWH0iVLv+/MYeDj9BopSC/W+HAxvouPQU/GfxSnRO7gUA MBqNyFz2Gh59/nWHgs08WolBN6hBQhhwPcNAVXMgkQogiLY8ZhU0iJ3RjKrhAAMPqtxseeyWmy3B H838bbh+ETAPjQLqhFdUxeGLXyuQfa4GR68Y7S4YVQoa3WIjcHMrHg+khKJPrApQUDAPjgSXpIFi db79J2CdR9H0UGuhyddxAF5XP19x1WKOauAqpXNroPj0irc/yrX+xKlgeiwWAHDXJ1eQ/bvYdz1z TDqWZGbZPXfjijdw36Mv2H1Pq2ZxcU57YURqFhwBVWAAnW8AlacHfa4GVLljS4QIhoJ5dEtwPUIB AJUGHu/+eB2Lfypza7EIAEk6DVaM0loEC0tUm/KDSw6nAqaJbSwOESusCsppWaDDWnldV16/oHHz DHHqM0egXJIXMFcpn6gR/vJ7vJePMwXiUbWkqBCR0TEOz+/dMRJHLtj3oB2f1Q4J0UpRW6WBx/Va HhV6DjUmgsoGAcihQTTCVTRaBDOIaeDlsQdVZARzvNK5+5ahYPpXa0Esp64acM+aIqfTG1dYMDQK swZaXKbM0UqwX161exyJUsL4ZJwwigMAnTgUylHveV1XXn30S9GfT5WYhH/31DE4U1D/nkpBOxUp ADwweiSOLLL/SPuobs59ttiI/CoKf5TUujyKqRQ0YkKV6NmaRVKMEl1bBWFAh2BBwCTGYlWwum+Z Y5UWJ4l1dGMomMa0EkSafa4Goz8vcHsUtcecHSVo10KB0ckh4HqEgj5QZtek6M84AK9djPAcMX52 D0jh6fqLV3FQvvNnwFOfjXPjQUIYbDpZhfHrCkTvnTqyF1179nN47p6t63BbxniH77uDK4u1JJ0G t3dQYFiSBgM7BIunFgYezKFyMPvKwA2JEh733hRpw77mPNsOoUG001EVKhrGp9uL4gColl2gfPgr eDMOwGsGf+74BpFIAenk59OnLUb6EV00SNJpRO8tfdX+HJTjOOzI/Agr318kak/SaTAuPQVTMwa4 9NkqBY2pGQPww6bVKKrQ4+K1WtQaOeRfysMPm1Zj0exJGJeegjitZV54pqAay/eX4a5VV9BuwZ94 elsxTl2te/QH0eAGtIDx+Q4+FSlgcXCsqzPuc91DAJUDqdirB1B4GtzxDV7tj1cUb/XnN3SVUpf1 UC6/5I3LN5uGc6nsczW4a5V4YffT9i/Rf+h9AIDfftmHlW+/jDVb96C0xow4rQr9b0rEqHsfwOD7 piBcG4UdmR/hwSnTnbpe47QqPP3YQ5g4+w2EhrvmwbqY+xuyNq3G1m++QdbhHJH4esVr8VTfIIxO rg+mOXXVgDtW5jvtR3MY1EltsRcDUKzOdxo5ZpweKzKLUcERUE7LgqT2BTB9P5/oF3YSvbg4FSGA ZF6mYVFC3+bcriUAhJdWzZLP3plH0pJjhf+PS08hP2xaTXjOTBry2TvzROc2fsVpVWTlgtnEbBaf 5y5l14rJygWzSa94cV+TdBqydpyO5M2NJ3FaldO+NPx+49JTyPKXZ5CVC2aTOZMzbK5r76VS0MJv Zu4X4fT35eJUNhowfT9fOlE7fHEu0b+RKO7g/a0CLkybF0MRw+z2Qh8fvCnM5sb0iteSlQtmk6qq CrviWTR7klMxLJo9iRgMhmYJ1B5H/vcdGZeeYiMiR31p+Jo5Jp2UXSu2uSbP806/j/VV/HJHyz0d FtX0YHB/K7FY30gk3ooDaPYc1Zy9EDb+/J3S8NQIMBTMQyJFnpRH+oZDpbB8/bTkWOzeshaHz1/D lBfegkYTKjqdEIK5U0ZitoPV/7j0FJw8k4Nn3loFpVJp95jm0HPgEKzNOoqcE4cxLj0FAJqck2rV LHZvWYslmVkI10bZvE9RFJ55axWGpya51AfKhbUGs7PEth5A9kKXrt8UzRIql7OT8H/sFbWxP153 3VjtB0iUEsZH2womlKIqDlM2FGLg/11Ct9gI7N6yFrtP5CFtxDj75xOCaaNuxYJVW2zei9OqsPO/ K7E26yhax8X79HsAQOfkXlibdRQ//7AFveK1Do9L0mlw9MQph9+pIa2ibUVsRatmEWoNPjE0LVSq 3Az2R3EsBf/HXq/UA/BYqHbz80tNFh+xROATNTA+UT/Jzz5Xg/4f5GPjySosmj0JB3KLmryZ00bd ipVbfrJpn5oxAKcuFOCO+6f4pO/O6DtoBA7kFmHR7EnCU8FKkk6D/x05g7iOCU1ep7K8DDt/Ouzw /VvjGyyOLrnmRGD+dx1UqUnU5o16AB4b/KXkz7cH1zMM5lExFsM4R7BwVykW7CpFnFaFAz9m48a+ aU1eY+6UkTYi1apZrF6xBHc/ON1rfa2ursTh7G04ffQgcs+eRnFJCSprDHj1nf9z2E+GYfDMW6tw 2933455RIwVvVP8+NyFK17bJz6wsL8OIAd2derHu7V43BTLwoK+4mNwYgDgAh/AVV4l+UbJo4myc 2CbwC6a6l7lfhNCv4pc7kkGd1AQASUuOJUVX811awNhbaKQlx5IrF897ZYF05eJ5smj2JJKWHGt3 YbRo9iSXr1VRdp0MT00Szh2XnuJ0UbdtzTKSpNM4XUQl6TSk8rUbLAupUTFu3wPjxDbihdWiZMJX XPXvKGbcOkvcidduIHyUMuACbSzS3Oc6CDckLTnW4Wq+MRs+XGhz4+ZMzmi2yYnnebJtzTKRqOy9 0pJj3b622WwmUzMGCNcYnpok6u/Fc2fJ0rnTXDZL/fh4bP29DWfdvg98lJLo64QuDGZbZ3ksVLeN sXb9+T9dl0TwMNczTMiUzCszI31lAfJK9egVr8WeE3/arObt8cuPO9E/fZiwqvbGo57wHD5f8gre fHuxTVCMPY787zsk970Nl86fQcGfuTDU1uJ6cT7CWkRBHRqOFjGt0T6xu13rxItTRwkLv+GpSWgV HYW9h361+7lJOo3d9rXjdIJjgc26BsbDtHbzsChRHAAAKMavhSdxAG6dIGV/Pp+ogelBHcBQKKri 0P+DfOSV6qFS0Dj+y0Eh1tQZ14qLcFNiO2HelqTTYMO2nU5jAZrimy+W45X/vOQwAssejgTUmDit CvFtonFj1wSk3zUSt436FzSaUDw5djCWrv+hyfNX3tsSt3ZU47PD5fjwgCUreM3Ylhh0gyXQhc6t aV62rRfjANw62Hx0PTF/N0/Uxm4sDHgpcxLOwvhUOyCIRqWBx8AVV4UbvfzlGXj8P0ubuIJlNMro 3xXb9p8BYLGtfr3nV7s2SFc4f+Y4npoyVrieP1ApaAzunYBHHpuOzNUfY90Px5wePz01Au8Mt6SU mDgCvZkI5ig6twaKzIJmD0ANn3JW2DtfBdtjjG+ESmrLiPGjO0Fq6utmSsKfz1AwPtpWMEE1DI5O S47FruMXQVFNf823n50sGPTHpafg028PemS85zgO777wCOYt+czrgSLuEKdV2V3Rx2lV6BRJIzFa iWFJGmH0bIi3i2zYxAGoI6F85Du34gBcNk+Zf3pPJFJAGvX2zUMihR9hftY1UQT/ko8+d0mkB7K3 Yt6SzyzXmD4GL76/zqXzGpN78gjGjxzi1mPeVzQWaa94Lb4aG+EwYJsqNQE1HNhtxV5PZ2e3FQtZ FgBAaq65XQ/AJYO/lPLzG8LHqcClWiKTss/VYEGDSf/UjAEu2Uory8vwwP0PQG/i8dk78zBvWaZH Iv144bO4sefNkhCpPY5cKMXJq2JbKFVqAn2qyrIY/u9VKJdf8sk99UY9AJdGVEn68+tyhcBQqDTw eGxz/WivVbNYuHKjS5d5+qERKKo0YvMnizFy4lNud6O6uhKPjBzY5HxQCjyzvQxHZ1ge9cyhcrCb i/z22czOEtt6AG7EATQ5okrVn8/1DRcqn7z8/TXRo+7Jifc2mWICADsyP8KmrJ/xzfpPPRLp+TPH 0buT7i8hUsASlG2t9ML1CHMcDO0DmhsH4LSnxGyQpj9fRYNLswRlnLpqwPIG+3hq1SyefP2DJi9R WV6Gp5+ehW+3bsKge/7l9Fij0Tbna++ODejTq5dLZiQp8e6Buse/ggLXM8yvn+0wDsBsaFKsToXK HfxYkv58LjVCsM0918jR0DI8CCMGdEeX1iHYu8NxOsSSuY/hkzXr0HfQCKeftWfrOky862ZR2+rF L2FwxhifRdb7kiMXSoXUFuv83m/YqTBOyi+DO/hxk6c6FCpfcVWS9fZJCANzXSpv9rkamzz9MwXV 2HPyEnp07SSklzQmNycHw+5/uEmR7sj8CEPvnYDv9p8Cx1nm6K8+MRYPP/1qQE1PzeXTwxa7N9Eq wMc5LmTsCxzuC9BEHIBDoZr3SLPePjewhTAh/8/uWrvHaNUsFq3a5PAaHW+4AT0HDnH6OdlffY57 HnoMehOP0hozTh3+CU+OHYyXlktjE9vmsO1s/X0lsf4VKuBgX4A9zvcFsLvql2J+PgCQKKXIHOXI FPTmi085DWRmGOfFHw5kb8XdYyaKRs2x99ztdD46PDUJwybMQLt27dC6dWtUV1fjxIkT2LZtK3Zl 7ZTUCJxXqkdemRlxESz49sFg9pU1fZIXsVsP4LdtTusB2DRK2Z9vLSFj4gj6LC+wKxx3vFH2OH5g D24fNNjl+Wdyty548623MXToUIfH5Obk4KlZT2H79h0Oj/E31sATqtQE5aI//d8BN+MAbEZUqebn 84kaoSrIJ4cr7IpUq2axenOWxyLNz7uAEXcNdVmkw4YNxfp165pMh+6ckIBvv92OJ5+ciaVLvVOh OU6rwo2JHdAqOgrRURYLSHV1NS7kXcG5P/KatEbs/7MWo5NDLHlkDOX/BbK9fQGc1AMQCZXXVxKT ROrti1DRFuM+LDlPr2TZf+SvWPyqSykY9qiurkTGbb1drtuU3K2LjUg5jsOGL/+LAwcPIjExCRMm jBeF4i1ZshS///67xyNrr3gtHhg9EvdNmYV2nbs6PfZacRE2f/w21maux56TtvEY+RX1f4ykhSIg 0zq7+wL8uAS8vpLQqlDHo41U8/NNo2KE/ozqFmI32HdqxoBmBTQ3Tkdu6rV9+3bRNTLXrSUx0VGi Y7RqlnzwwQei4/Iv5bmc6mx9pSXHku3rVnj8/Y79vNsmWLtXvFYS99jVegDCql+y/vxEjais+eZT VTbH9IrXYtmXTcdfOuK1f49zy7uU3K2LaE66Y8cOTHxoAoqKxTZdVhOB0aPE+2vp2sZi2uPiStzO GJ6ahOnTH4dBX40D2VtRcNn9aLUb+6Zh677T+GHTaqF0UHVtvd+f7xu4vQjcjgMwrp8oVvZ8z1IQ vPniw1miryuAkDc3nmjVrM1oo1Wz5OK5sx6PNps/WezW6AaAzJw5Q3SN5G5dbI5RKWiyb98+u5+5 fft2tz+z8XdOS44ly1+e4XYOlzW/SpRu4mKBCZ/e5/mN0lbWTxQJlQYc+PP3lAbWn89Qloj9Opvp xC+v2ixyVAoaWzau83heeiB7K8ZOe8bt8xIT64s2FBcW4OSp0zbHTHv8CaSmpto9v2N882oAlNaY sefkJUx/+T20adcR4wf3wPkzx106NzQ8Aht3H8Pg3gm4Y+WVei/VgBZ+d6laocrNYPeI1x2N4wBo qfrzzaNbOowztbLm/dcdep+aIvfkEdw1YrRH9s127doJ/86/aj8C6cLhLDz55Eysz1yHHTt2oLiw vtxlpLaF3XNcRatm0Stei7TkWKQlxyL3Qh6GD+qH1Ytfcul8pVKJjbuPoW9iG9yxMh9FdeXPzRkx ILqgZvXNU5qKA2Cl6M/nbteKyiousJNctmj2JNw77XmPrp978ggGpw3w2Fd/8eJF4d/tY9vYPWbb /jPA/jOwJsFs374dQ4fqAADXSt0fBIanJmH06Hsx+N6HHTozKsvLQHgOFO3coQFYxPr1nl9xS7f2 uCezDLsnaaFQWIoDK9/L8//9d1QPoC4OgOaOrBEdT1VxAfXncz3DLJWWYdmfdEJmoc0x86ePwTNv rfLo+laRNqd8+Nmz9XlQ4dooDBvm2NgPADHRURg0aJDw/19//cXlzxqemoScE4exdd9pPDRrvlOP W2h4hEsitRKujcKGbTtx6lIZnq8L7iExSpiHRLp8DW9Cn6222dzCqk+a6TVB9AYJYcAniovd+gs+ USMYgIuqOAz/rNBm1JszOQPzlnm2WezxA3uaLVIAyFy3TghSAYAP3nvXprROQ5YuXSrKv1rzxRdN foZWzWLDhwuxdd9plzJoPaVrz3748I25WL6/TNhCkxvQwu/BKoDl/pNGqTJWfdLMzVNAhYtLwJiH R4s2EPAHXM8wy+IJlg0bhnxSaCOoOZMz8PrHX3t0/QPZW3H7oMHNFikAFBWXYOXKlcL/4zom4PjJ 00ju1kV0XEx0FDLXrcWYsfX1rY4fP96kwb9XvBa/Hj3m8dTGXR6aNR/DU5Pw2OZrwuYYVgeL32Ao i+4aQIW3BXOzpbYXBTjeZc/TwgPuwvWLEHaCqzTwGPr5dZuAk/nTx3g8ku7I/EiIhPIWMdFROPbr r9C1jRW1V5aX4eRvp9EhLtbmPY7j0COlu10rgZU5kzMwf8WmJgNnvE3e+RwkJHXB5N5hQgq1P1Ph udu1wpTPiuKeZbDuBkgDAJMwhKI79BcdZE7TWjb28iUMBfOwKEGkRVUcBq64aiPSlQtmeyzSjxc+ i2Hjpnk9eqmouARDht6JynJx5FFoeARSU1NtREp4DiNGDHcoUq2axfZ1K/D6x1/7XaSA5akw55H7 sepwBXKKLe5U7s4ovzxZSTgLc5q4jCbdoT8ablkp/IMvziXGVSPQMInP6W4YzUVFwzRWJwSaNCzB IxyioLHhk/c8KqdDGpW38RUx0VE4tHePU997ZXkZ+vXv51Ckw1OTsGrDTkS3jrX7vr+orq5EXIwW t8arkDneMg1jvyn2eRig+f5WgpUHAEAxUE7eCjq6s6BPYQVAR3emmJvEtUK5HqE+mVTzcSoY/x0n iPTQJT36vn9JJFJreUhPRFpZXoaM/l19LlLAMrK2T+iGR0YOROHZQ/XB5pwRxfmX8H+vzERYRAu7 Io3TqoQFU6BFCsBSDmjivdh8qgqH6uqhcmlan46qfJxKLFIAzE3jRCIFGsWjWqOnfFYNhaHA3doC 5tvrv/yaXyrw7y3FokdzWnIsvsw6iOiWOrc/4vyZ4xg+qJ+kk+5UChqz/jUcz7/zmcs7pviL4sIC xMW2xdAEdf2o6sO5qr0qKoppWWgcPSWyqdCqUIoZ+KToQqStyiuuNWuJcvPgSCEXf8qGQkzdWCgS 6fzpY7Dr2B8eiTT7q88lnRkap1Vh/vQxyLt0Ga9//LXkRAoA0S11mDCsHzafqkJemcU0yHdvugqi J3A9w2x2wmYGPmkjUsAfEf7WUTRNK+wdf+iSHtM2l9oIyrrbcYhGg9DQECQndUaHjp1xyx0ZTVbU e+/FRzHz9RXu98/HJOk06N/nJjzwrylIyxgfkIVSQ3ZkfoSdWy3ByRqNBi1btUJi9164OX2kUBDO ulvhnNu1eKluJa584w/vxn64GeFvd/LhtRqo1v06u9Vv4jU/65pdl2hTxGlVGDKgN6bNmitKzGtu pRKVgkbfxDZI7XMTOnfpjo5JyQhtEY0IrcUSYTDUovL6NdRWV6CmshwV10tQVlqKmuoKlJeVQ6+v RXV1/R9cZGQUIqNjkJDcE937DfboyeBLivMv4dZeSXafOr3itbjjtgGY9PQr6NOrF0JULHJnW+bO 3l5UuVs71eEs2bh1FuF/21bf4MEu0Q1Xc45GUU/oFa/FonffR+sOnTFySJrb11QpaNxza3eMfWgK 7rh/qk+23JEy+XkXkJyUgNIaM0Z1C0HrMBa7/jCJfkeVgobexOPIzDh0axXk1a3s7e5K3XU4lCMW O9Sjwzf4iqvEuGKwKGXanc423H7cV/t1Wn9MV0nSafDopAfx0KzXPK57+nfhmy+WY/iEJxCnVWHv Y60RE8Igp9iIb89U48ODVYIFRtgSnSMIeu2CV3LnrEmaAqwKymlZoMNaOdSjQwc1HdaKYlMfFbXx ndUuxwGYB1kMuEVVHCZkFrosqF7xWiydOw0//7AF504fQ86Jw/hh02rMmZwhRKdbcfWaacmx2LZm GX67UokZr334jxcpANz94HSMS09BXqkeb+62TMUSopWYNbAFcmfH4tvJbZCk0wj+fzAU+PbBzf7c hkmaVtjUR52KFGiikC8xGyzFexuEAVKlJigXX3QaBkZCGBjnWqJ83JmTDk9Nwpa9vznMIi0vLUF8 rM7l8LzhqUmYM/+NJiuieAtiqMKpvduxc+dO/LjvZxRcLYRB3QrDb+6Eu4YNxS13jQcVFNL0hfxE 7skjSOjeGwBwfFY7JETbToE2nawS6vk3e68GhoJxVjvRDopUeFtLUV82yKkWndaeotggih0kDowg WgW4W50H/jbsyEEXN9ICgIKrhSgpuOzw/TNH96PGhVF0XHoKjv28G1v3nfaPSM16fP3pu3jq4VHY uXMnlEoFBva7Bf363ITCwiIsWLUF/UY/ilaxHXAy+0vf98dFOif3ErasXLSnPkaWuqwXdupruJs1 36F5Iyp3awuRNgCAHfR8kyIFXCyNblw/UZyqYuChfPeiQ3NFw/lpj/fy3VrsWOvQ9+5xI3RtYmE0 GnDl0kXsP/Sr3bTfhoxLT8GcN5Y1a3MITygvLUF4eBjA2F+UFZ49hHnPPyNsrnbih/8iedD9/uyi Qw5kb8Ut6RlQKWjkPtseMSEM6FNVYLcUgRsWbeM1CnrlvEfz1Ib7LFihO/SHcsynLmnQpYPcjQMg uiAYZ8QBAMauLbCbOeptjv2826UK04Hk/16Ziekvv4eY6CgU5p0DVOF++VyO43Dq8E/448xRlF+/ jsiYlkjq2R8dk24EAHRpHYIzBdVYmhGDaX3DAROxCJIj4ONUMA+PFgzUxYyAAAAOQElEQVTzitX5 HgXWu+LPd4ZLlVzdjQOgioyAyTKHTetou5mBt0nSaQIq0vy8C3j1ibHo3TESwUoGkRoFeneMxI7M j0THPTZvMZK7dUFRcQlO7tvpl77NnTISMWEqpNxyG0ZNmoWHn34Vwyc8gRu6pKBdZDBefWIs7rj1 FgDA1tN1A4qCAt+pbgufPD2UH14Gu7EQMPDgk9wPqnfVn+8Ml0sOMwOfAqUWxws2DnQV4AjoPyyV 9kZ1C3Ea/e4NZv37cZ9e3xHFhQV4cuxgdLyhE15avh6nLpWhb2IbdO+ow6lLZRg2bhq++WK5cDxF M1jwnKWvOecu+Lx/33yxHAtWbREtPlUKGlo1C5WCRl6pHi8tXy/sSbXvTz1MdYtk0rpBkh9HwPxS gaA3/rAMQm5iExCtjgQ7YIZb13BZQe7GATA/W7wYMSEMXkp3vGV3c5k5Jh1TXnBestAXbFzxBhLj 47B0/Q/oFhuBDR8uRHlVLXafyMPuE3k48GM2VAoazz77nOi8djrLTWsd3bxM1KYouHwJ02fWp4LH aVU4PqsdyuZ3RP68Diib3xG5z3XA0owYJOkso6TexONoviV9mm9nZ+Gk5932Tjny57uzdQ/g5jbo zI33gWopTrfg7oyyWwu+YcHWf/eLwKhu3jXLaNUsVi6YjSWZWV69blOUl5Zg/OAeuO/RFwAAn70z D4fOleDeac+LPFw39k1D38Q2NgvJynLL6rpjlx4+6yPHcRg3rJ8obHLhnS1szE9xESym9Q3H0Rmt sTQjBioFjaN1u0iLRlRPUdEWfTSAatkFzI3up7i7JVSKZig2fa6ojYQwlrA9O7DbigEDDwVDIXO8 DkszYqBVNy9rIE6rwpzJGTh7Ic/vI+neHRvQvVOsEFcQomLRrVc/u3bf6upKnDhfYOOk+Hb7DkzN GICWiX180kdCCB4bfZvIQvLgTWGCmYk+VQV2YyHYb4pBn6oS7OHT+oZj7+P1uXMkhLFJtHMX8+1a m2uw6XPd3l4ScFOoAMDE9aHorsNFbVxqBEiUrWmGKjFC8ckVIQV2Wt9wrBnrftJYkk6DqRkDsH3d CvxeUI7XP/7ar8EexfmX8MjIgRgw7H7kleoxf/oYLH95BvJK9eifPkw0D7WyYOYElNaYMWXsSKGt vLQEJ8/kYsUax3sLNJcXp44SzGCA5Q/73RGW6QZVaoJikyW2lNlXBsXaAigX/Sk8+bq1CrKs+uto /Mh2h4ZFl63QXYd7tGEv4MHu0oD7cQAkhIH5vlaC6+zpbcVYvr8MWjWLxa++AF3bOBRczkN5aRGM RhMiWkQiQqtFh6Qe6HzjzQGL2ywvLcFbz07B4s+3QW/iEadVYfWnq5A2wmIBaZg0uHTuNMx4zbLn werFL+Hhp19Fkk6DY3+WClOCwrOH0LJTikN7a3Owl3qjUtDY+3hbdGtleYwrPnC84RnXLwLmoeIc qeZETHniz/cJ5n3LbUtUJmocF8NiKGJ4qh3RL+xEKl+7gTx4U5hQ9Gv+9DHEYDB4UuPMJ1y5eJ7M mZwhFGVTKWgyZ3IGqaqqsDn22M+7SZxWZSmeNiadzJ8+RihklnPisF/6azAYbMpmqhQ0+XZyG+He mG/XNl2sTBck3CP9wk7EdH8rz0pJJmpstGHet7xZpVc8Vjcx1RLjymFuxQGQKCVM09qChDAwcQQL d5UKcQBJOg2ee2YWxj7xYkDC7oxGI7I3fYYPli1B1uEcUcDLzz9sceqKzc+7gPS+3YWFU5JOg693 7vFp4YiGnz3+7jQbr5219DngZpImQ8E8Ihpcn3DP0pAc+fOnbgelCPbvaGqFy9lp+5fTxF8urwsi hrnxwvHfTm5DknQaYSSI06rInMkZ5Mj/viM8Z/bpSFRVVUG2rVlGpmYMsClpOS49hWz4cCFRKWiS lhzrcMT/afuXoiK5UzMGkIqy6z7tt5Vta5bZ9FuloMnacbr68o0T2xDCUB6Nioa58W6fa75da/uk dXF3Pmc0W+HuxgEAFr+v6UGdMFk3cQTrj1Vi8b4qkTlHq2bRL6UTBva7Bd173YLk1CE2+fLucK24 CL/s3oqDP2Zj14/7cODsFdHIGadV4cFRQzDthTeFUpY7Mj/CsHHTMC49BV98/ytKS4px6IevsXPr Bmz+fq9gAkpLjsXCd5f5JQimvLQEjz8w2CarQatmsWZsS2Frc+qyHspVVzyOISXhLCgD7/L5zfXn O6PZF/C4HoCdjFTAkgnw32OV2HZWb7f8jkpBo0NUMFpGaREaGoJQdRCio8S2uppaA6qrK1FZY0DB 1UJU1xpQWG5wGB5oFWiP3n3RIro1amsqoa+uRFlpKQquXELmV9twpqAaWjUruoZWzWL04Fts0mN8 BeE5rHrzBTz32rs23yVJp8H6sVGCrZTOrYHi83y/VuVrrj/fGV6ZM5i+n0+4X8RVAZ2tMBtCwllw Q6LAdQ+xyR/PKTbiUJ4ex/INOHiVRlFZjVdqR3mKdSeSgf1uQf8hGeiddpcoWa+6uhL7vv0v7rh/ ilc/lxCCLZ8twZy58+xGok1PjcDLd0QitG4kY45Wgt1U6FeR8nEqmB4TP+2YnhOguOMlr2jMKxch tWXEuGIwSG29KcPdiTgJYcD3CQd3Y6iwa7Q9TBzBhVITyvU8Kg088htMMWpMBGoFBbXScsMigmmE BtFoFcpCxVIoqjKjsIpDWS2PkmoOhZVmlOt55FeYcfYaEUQwPDUJI+6+GxFaLaJ0cYjt1BWxHZMc LvKMRiM+Xjgby1aswoZtO70WZlhdXYnVb7+IZStW2RVokk6Dt4dFCI96cATsjhK/b3AG2MnPD46A clqW265SR3htFWY+up6Yv5snavO0cAGJUoJPUINvHwzSOsgm2NYXmDiCkavzhcrW49JT8Oyr7zqN yirOv4TVS17G+6vWoajS6HH5oYYQnsO+nV/h8xXvY1PWz3anK3FaFebdHo4xKaFQ1D2FqCIjFOuv giow2Bzva7ieYaL9ogCAvfNVsD3GeE1fXruQL3f8IyEMiFYBEq0EwlmQcBZEzQBKGkRdN3FX0gBL AWYCGC2fR9XwgJEHVcNZItZDWBANYzlHzYBoGNHEv7HJDLCIov9NiWjfrh1aaCNRW1ODszlnkXsh T1TMrVe8FtOmTMZtI8cLcZ4ufTdCcOHsCez+ei1278rCd/tPOZxLD+qkxqTe4aKoe3AE7K5SSyn7 QFQJdzM/31O8atfyWj0Af8JYYi9NY1oJos0pNmLRnuvYeLLKYQKhSkFjaIIarcNYm4WfVs2ie0cd WreMRHRUFDQaDVSqYASr1bheeg3V1dUoLilB7oU8XLha4TQHLEmnwYSUYNzbPRRxEQ3iJOpC75hd gd0UxN38fE/xugHWuHkG4c82KFTrQT2AQECilDA90FI0zzJxBEfzDcgpMqK42mLViNYwSIhRokfr IOGxCwCnrhrw1ckqfP8nHG4m7ApJOg166hjcGh+MWzuqxeIEAAMP5lA5mH1lgd21Bg7y8xOHQjnq Pa/ryusXbG49gEDD9QwDN7CF0wVdU1QaeBy6pMfxfANOFxpRUGlGOadCda0BrUMsj+ewIBqtw1iE q2h00CqQEKNEUoxSWLmLO0VAn68FfaISzLHKgG4E0hB/+vN94tIy71tOzD8uEbV5mmsTKPg4FcgN avDtgkEiWEBdNwcrM4EqM4MuMIA6VwOq3Ay+Wwj4zhrwHYO9VqKRquJA/14D6nwNmN+qAr5pcmMa JnBaYQc+CbbfdJ9oyicX9SQO4G+BigbfPhh8fDBIyyDw7VSixZpdDDyocjOoIiOo6ybQF2pBFRgC /lh3SgD8+T6pfU4pgqnG+wJY6wH4a1+AgKDnLZkNDZ4cJIQBQlmQukqGVF3SI2o4S5zuX/AP12F+ vg+DTnyWdcckDKHouJtFbeaBLZodNf5Xg6riQBUYQOfpQefpLaOldcT8C4qUhDAwDxSv8um4m0X1 9n2BT9ND2TteAqgGwgyiwQ1zkLkq85eAGxYtns5QjOU++xifCtWf+wLI+B5v5Od7im8T7gGwA2aA ChankjisByAjaWzy84Mj3M7P9xSfC5UKjqCYATNFbd7aF0DGf9jNzx8w02tBJ03hc6ECANNjLKjo BFGbo3oAMhLEXn5+dAKYHmP91gW/KIWiGarxhNtZPQAZaWE3P/+Ol7wadNIUfhvSmLg+FJ0o3i7c UT0AGelgNz8/cajXg06awq/PXva2ZwG2wTzHzo7CMtLCZqdxVmW5j37Gr0KlI9o2a18AGf/isN5+ RFu/pz37fTXD9JkEKrytqK1xhQ4ZCcBQlvvSACq8LZg+kwLSHb8LlVIE2+4LEKME19c/1ZdlXIPr G24T6uhrf74zAmIfshsHMDjyHxcHIFVICGPZs7YB/vDnOyNghkw5DkC6BMqf74yACVWOA5AmgfTn OyOgriE5DkB6BNKf74yAClWOA5AWgfbnOyPgznY6ZYwcByAFHPjz6ZQxAeqQmICrgWZYOQ5AAjjy 59MMG/DRFJCAUAE5DiDQSMWf7wxJCBWQ4wACiVT8+c6QjFDlOIDAICV/vjMkI1RAjgPwOxLz5ztD UkKV4wD8i9T8+c6QlFABOQ7AX0jRn+8MyQkVcBAH0OhHlWke3OBIyfnznSFJodqNA+gTLscBeAk+ TgWuj3g6JQV/vjMkKVRAjgPwJVL15zvDJ0XSvAEVHEGZf/mCmL9/RWizxgEwv1UFsGd/bbiuIZL1 5ztD0p3jOTMxfToSpDgn0F3520JFJ0Ax8WvJuEodIdlHP2A/DkDGu0jJn+8MSQsVsB8HIOMdpObP d4bkhQrYiQOQaT4S9OfLyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI/H34f4DnQZLCUbKg AAAAAElFTkSuQmCC "
+       height="18.421789"
+       width="18.421789" />
+    <path
+       style="fill:#455c91;fill-opacity:1;stroke:#485c90;stroke-width:0.065px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 13.984312,12.726634 0.03325,2.630469 c -0.626212,1.348342 -1.864809,3.416425 -2.757403,4.184964 l -0.113641,-0.140573 -6.1504829,-0.01206 c -0.316416,-0.01349 -0.654604,0.350565 -0.635432,0.60017 l 0.605343,7.881219 c 0.01985,0.258488 0.294567,0.581835 0.581835,0.581835 l 5.4774769,0 c 0.214377,0 0.508195,-0.213055 0.517186,-0.476047 l 0.02351,-0.687624 c 0.177836,0.252545 0.659175,0.628853 1.075513,0.628853 l 7.381664,0 c 0.924147,0 2.348823,-0.984515 1.880679,-2.644705 0.529304,-0.423588 0.842626,-1.143065 0.52894,-2.056992 0.555062,-0.453627 0.95877,-1.306413 0.493678,-2.068746 1.479159,-1.239472 0.519291,-2.973824 -0.622974,-2.973824 l -4.972045,0 c 0.185997,-0.813338 0.477909,-1.644292 0.458416,-2.738738 -0.01684,-0.945207 -0.644701,-2.322763 -1.093145,-3.056102 -0.187053,-0.30589 -1.913467,-0.895396 -2.712363,0.347897 z"
+       id="path3009"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccssssscsccccscssc" />
+    <path
+       style="fill:#6e7fb3;fill-opacity:1;stroke:none"
+       d="m 5.0692251,20.14975 5.1806329,0 0.0121,7.613594 -4.6117319,0 z"
+       id="path3764"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#6475ab;fill-opacity:1;stroke:none"
+       d="m 5.6260221,21.178614 4.1033522,0 0,6.124767 -3.5828682,0 z"
+       id="path2994"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#edf5f7;fill-opacity:1;stroke:none"
+       d="m 16.482302,18.888451 c 0.237198,-0.953632 0.410241,-2.014256 0.524972,-3.030803 0.0282,-0.249886 0.02697,-0.465789 -0.01088,-0.672916 -0.149763,-0.819429 -0.492693,-1.551175 -0.814688,-2.288077 -0.318932,-0.250948 -0.943214,-0.350861 -1.411378,0.02979 l 0,2.586337 c -0.785404,1.538476 -1.671195,3.019589 -2.765007,4.381833 l -1.031019,0.719827 0,5.987243 0.714095,0.0028 c 0,0 0.946752,0.578944 0.99646,0.55409 0.08285,0.04142 7.381163,0.02059 7.381163,0.02059 0.395654,0.0082 1.82301,-1.034467 0.913858,-1.848307 -0.121149,-0.07432 -0.105237,-0.297756 0.0083,-0.372073 0.568248,-0.102002 1.256969,-1.17096 0.537522,-1.733988 -0.122527,-0.136544 -0.03468,-0.350662 0.110298,-0.366631 0.425004,-0.205227 1.152864,-0.892181 0.492078,-1.721683 -0.13333,-0.0679 -0.13908,-0.24295 -0.01515,-0.348641 0.639145,-0.08914 1.448755,-1.545236 0.108634,-1.89517 z"
+       id="path2987"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssccccccccccccccccc" />
+    <path
+       style="fill:#dce4e7;fill-opacity:1;stroke:none"
+       d="m 11.500825,26.603743 0,-6.359462 -0.528281,0.358422 0.0024,6.000473 z"
+       id="path3002"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#dce4e7;fill-opacity:1;stroke:none"
+       d="m 15.460842,12.670845 0.613058,2.64244 -1.623773,2.883025 c -0.168273,0.29877 0.03515,0.601651 0.277532,0.613058 l 1.760469,0.08284 c 0.268792,-1.21509 0.593159,-2.696958 0.527037,-3.612067 -0.120278,-0.638095 -0.379047,-1.44522 -0.833741,-2.393188 -0.253938,-0.172262 -0.464918,-0.216113 -0.720582,-0.216113 z"
+       id="path3000"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccc" />
+    <path
+       style="fill:#dce4e7;fill-opacity:1;stroke:none"
+       d="m 19.967851,18.884443 c 0.576951,0.54845 0.230529,1.581917 -0.27675,1.947465 -0.09622,0.0555 -0.11695,0.192137 -0.04686,0.281187 0.559147,0.639226 -0.184326,1.716857 -0.421781,1.827717 -0.07698,0.06918 -0.08661,0.149591 -0.0703,0.234322 0.636824,0.892478 -0.09901,1.635413 -0.351484,1.804285 -0.08352,0.07488 -0.109404,0.204568 -0.04686,0.328051 0.555499,0.87442 -0.08777,1.493624 -0.454649,1.878505 l 1.812641,0.0038 c 0.348549,0.01747 1.811331,-1.045389 0.841892,-1.880176 -0.108877,-0.09376 -0.03864,-0.336024 0.0358,-0.349382 0.479935,-0.08613 1.327001,-1.100218 0.534201,-1.743525 -0.05537,-0.04493 -0.102552,-0.267797 0.108928,-0.361267 0.655022,-0.28951 1.059493,-0.985784 0.49944,-1.725413 -0.148962,-0.08391 -0.130345,-0.265904 -0.01336,-0.338019 1.094277,-0.325978 1.119441,-1.776095 0.103493,-1.903211 z"
+       id="path2985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccsssscccc" />
+    <g
+       transform="matrix(0.065,0,0,0.065,4.3429681,11.929852)"
+       id="g3779">
+      <path
+         transform="matrix(0.59806884,0,0,0.59806884,30.309966,82.598928)"
+         sodipodi:open="true"
+         sodipodi:end="12.541589"
+         sodipodi:start="6.2585156"
+         d="m 80.03736,237.47695 c 0.188395,7.63513 -5.848379,13.97735 -13.483511,14.16575 -7.635132,0.18839 -13.977353,-5.84838 -14.165748,-13.48351 -0.188395,-7.63513 5.848379,-13.97736 13.483511,-14.16575 7.634528,-0.18838 13.976476,5.84746 14.16571,13.48196"
+         sodipodi:ry="13.828837"
+         sodipodi:rx="13.828837"
+         sodipodi:cy="237.81807"
+         sodipodi:cx="66.21273"
+         id="path3780"
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         transform="translate(-0.24218783,0.04882811)"
+         sodipodi:open="true"
+         sodipodi:end="12.541589"
+         sodipodi:start="6.2585156"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:ry="1.0498047"
+         sodipodi:rx="1.0498047"
+         sodipodi:cy="223.04004"
+         sodipodi:cx="68.334961"
+         id="path3782"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         id="path3790"
+         sodipodi:cx="68.334961"
+         sodipodi:cy="223.04004"
+         sodipodi:rx="1.0498047"
+         sodipodi:ry="1.0498047"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:start="6.2585156"
+         sodipodi:end="12.541589"
+         sodipodi:open="true"
+         transform="translate(3.3466792,0.04882811)" />
+      <path
+         transform="translate(3.3466792,3.6865236)"
+         sodipodi:open="true"
+         sodipodi:end="12.541589"
+         sodipodi:start="6.2585156"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:ry="1.0498047"
+         sodipodi:rx="1.0498047"
+         sodipodi:cy="223.04004"
+         sodipodi:cx="68.334961"
+         id="path3792"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         id="path3794"
+         sodipodi:cx="68.334961"
+         sodipodi:cy="223.04004"
+         sodipodi:rx="1.0498047"
+         sodipodi:ry="1.0498047"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:start="6.2585156"
+         sodipodi:end="12.541589"
+         sodipodi:open="true"
+         transform="translate(-0.24218783,3.6865236)" />
+    </g>
+  </g>
+</svg>

--- a/img/FacebookShare.svg
+++ b/img/FacebookShare.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64.607384"
+   height="31.538702"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Facebook.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.03"
+     inkscape:cx="25.018943"
+     inkscape:cy="27.000707"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1222"
+     inkscape:window-height="1419"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="0">
+    <sodipodi:guide
+       position="53.472539,0.8733177"
+       orientation="0,53.46875"
+       id="guide3203" />
+    <sodipodi:guide
+       position="64.675443,34.289776"
+       orientation="-24,0"
+       id="guide3205" />
+    <sodipodi:guide
+       position="53.472539,31.62976"
+       orientation="0,-53.46875"
+       id="guide3207" />
+    <sodipodi:guide
+       position="0.00378865,31.523359"
+       orientation="24,0"
+       id="guide3209" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-0.62121135,-8.4846564)">
+    <rect
+       style="fill:#f0f0f0;fill-opacity:1;stroke:#d7d7d7;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect2985"
+       width="52.482887"
+       height="23"
+       x="1.1212113"
+       y="8.9846563"
+       ry="2.1487894"
+       rx="2.1487894" />
+    <text
+       xml:space="preserve"
+       style="font-size:14.40710354px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#535353;fill-opacity:1;stroke:none;font-family:Sans"
+       x="25.624592"
+       y="24.967773"
+       id="text4002"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4004"
+         x="25.624592"
+         y="24.967773"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#535353;fill-opacity:1;font-family:Tahoma;-inkscape-font-specification:Tahoma">Like</tspan></text>
+    <image
+       y="21.60157"
+       x="46.806808"
+       id="image3042"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKoAAACqCAYAAAA9dtSCAAAABHNCSVQICAgIfAhkiAAAIABJREFU eJztnXl4E9Xex7+zJE2TbqQLBGiBIrQFikUWsSxWKSIoFMSFRa6yiYoXFMUFxKuooKIICq8ioiJC uQIioCDWAlcB2ZRVoBVQCrR0oXRvtpnz/pFm2mmWJmmWUefzPHkeOJmZnGS+PXPObzuAjIyMjIyM jIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjJehAt0BV+DLLhPjyqGAWR/orvx9YFVQTt0BOqLt X0IDdKA74Arm3W/JIvU2Zr3ld/2LIHmhcnmHCH92R6C78beEP7sDXN4hEuh+uAIb6A44g+fMxPTp yEB342+N+fv54DkzoRlW0lMAaQv12HqQ4hxRG7uxEMxvVQHq0V8frmsIzPe2FP5PinPAH1sfwB65 hmSFSmrLiHHFYFEbdVkP5peKAPXo7wHzSwW4vuEgbVVCG/fTUpDaMkIFR0h2VJXsHNX803sgtWWi NnZbcYB68/ei8e9Iastg/um9APXGNSQpVL44l3C/rhO1MYfKQefJK39vQOfpwRwqF7Vxv64DX5wr 2YWVJIVq/n4+QLj6BgMPJuta4Dr0N4TJugYY+PoGwll+d4kiOaFyOTsJn3dQ1MZmXQNVxTk4Q8YT qCoObKM/fj7vILicnZIcVSUlVGKqJebsN0RtVJERzIFyB2fINAfmQDmoIqOozZz9BoipVnJilZRQ uUOfgJRfFrWxO0oATnK/298Djlh+3waQ8svgDn0SoA45RjJC5csuE/P+D0VtdG4N6LPVAerRPwP6 bDXo3BpRm3n/h+DLLktqdJCMUG38+RyRzVF+gt1WLH5qSTAOQBJCtefPZ/aXgSoxOjhDxptQJUYw +8U2a6nFAQRcqDxnJo3NIlQVB3ZXaYB69M+E3VVqY1mxxgEEqEsiAi9UO/585rsSQM87OEPGJ+h5 y+/eACnFAQRUqKS2jHA/LRW1yf78wMH8UgHqstj7Z40DCFCXBAIqVNmfLz2kGgcQMKHa9ecfrZT9 +QGGztODOVopapNCHEDAhGrXn79dHk2lALO9WHJxAAERquzPlzZSjAPwu1Blf/5fA6nFAfhdqLI/ /y+CxOIA/CpU2Z//10JKcQB+Farsz//rIZU4AL8l93F5h4hp7XhRmxT8+SRKCT5BDb59MEgEC6gZ yxtmAqrMDPpiLegz1aAKDAHtZ6CwxgFwA1oIbdY4ACauj9+SAf0iVMJzxPhJhqgt0P58PlED8yCt KBuzMSRGCb6zGhgcCeqyHmx26T9ymsLuKgXfIwwkhBHazN/PB+E5QtGMX8TqF6FyRzOl489X0TCN bgm+W4ioOafYiFNXjSip5lBt5BGtYZAQo0SP1kFQMBRIWxVMD7UGc6gc7Nbif9biry4OoHE9AO5o pt+64HOhSik/n4SzME1qAxKjBAAUVXH48OcyfHigAqU1ZrvnaNUsxqaE4LnbtIgJYcD1CQeJUEDx ef4/SqyBrgfg88WUZPz5Klok0jW/VKDzW39iwa5ShyIFgNIaM5bvL0PKu3nIPmdZAfOd1TCNaeWX bkuJQMYB+FSoUvLnm4dGCSJd/ON1TN1YCL3J9alHaY0Zd626gk0nLeWE+G4h4PpF+KSvUiWQcQA+ ffRLxZ9PdEHg+oQDADadrMKcRoZsd5i8oRDdWimREK2EeXAk6OOV0nX9MhT4NkEgsSqQcBYIYUEU FCgTAUw8qCIjqGsmUJf1Ln8HZnsxuC4aIKhujPNTHIDPhMrl7CSmr54Qf1iA/PlcX4tITRzBC99d b9a19CYes7YV49tJbYAgGtzAFmC3ey58X8AnasD1DAOfoAEUrk0fqct6MGeqLSkpTha51jgA893R 9Z9XFwfAJAzx2VzVJ0IlplpiXDlM1EaVmgLmz+e7WFb4W09XI6/U8bRDq2YRomJRVGl0Oi3I/r0G 2edqMOgGNfgeYYBEhEp0QTDdE2PX5FZUxeF6LYdyPQ+1gkKYioEulIGizrpE2qpgbquCOU0Ldk8p mP9dd7hYZA6Ug0uNANEqhDZrHAClCPaJWH0iVLv+/MYeDj9BopSC/W+HAxvouPQU/GfxSnRO7gUA MBqNyFz2Gh59/nWHgs08WolBN6hBQhhwPcNAVXMgkQogiLY8ZhU0iJ3RjKrhAAMPqtxseeyWmy3B H838bbh+ETAPjQLqhFdUxeGLXyuQfa4GR68Y7S4YVQoa3WIjcHMrHg+khKJPrApQUDAPjgSXpIFi db79J2CdR9H0UGuhyddxAF5XP19x1WKOauAqpXNroPj0irc/yrX+xKlgeiwWAHDXJ1eQ/bvYdz1z TDqWZGbZPXfjijdw36Mv2H1Pq2ZxcU57YURqFhwBVWAAnW8AlacHfa4GVLljS4QIhoJ5dEtwPUIB AJUGHu/+eB2Lfypza7EIAEk6DVaM0loEC0tUm/KDSw6nAqaJbSwOESusCsppWaDDWnldV16/oHHz DHHqM0egXJIXMFcpn6gR/vJ7vJePMwXiUbWkqBCR0TEOz+/dMRJHLtj3oB2f1Q4J0UpRW6WBx/Va HhV6DjUmgsoGAcihQTTCVTRaBDOIaeDlsQdVZARzvNK5+5ahYPpXa0Esp64acM+aIqfTG1dYMDQK swZaXKbM0UqwX161exyJUsL4ZJwwigMAnTgUylHveV1XXn30S9GfT5WYhH/31DE4U1D/nkpBOxUp ADwweiSOLLL/SPuobs59ttiI/CoKf5TUujyKqRQ0YkKV6NmaRVKMEl1bBWFAh2BBwCTGYlWwum+Z Y5UWJ4l1dGMomMa0EkSafa4Goz8vcHsUtcecHSVo10KB0ckh4HqEgj5QZtek6M84AK9djPAcMX52 D0jh6fqLV3FQvvNnwFOfjXPjQUIYbDpZhfHrCkTvnTqyF1179nN47p6t63BbxniH77uDK4u1JJ0G t3dQYFiSBgM7BIunFgYezKFyMPvKwA2JEh733hRpw77mPNsOoUG001EVKhrGp9uL4gColl2gfPgr eDMOwGsGf+74BpFIAenk59OnLUb6EV00SNJpRO8tfdX+HJTjOOzI/Agr318kak/SaTAuPQVTMwa4 9NkqBY2pGQPww6bVKKrQ4+K1WtQaOeRfysMPm1Zj0exJGJeegjitZV54pqAay/eX4a5VV9BuwZ94 elsxTl2te/QH0eAGtIDx+Q4+FSlgcXCsqzPuc91DAJUDqdirB1B4GtzxDV7tj1cUb/XnN3SVUpf1 UC6/5I3LN5uGc6nsczW4a5V4YffT9i/Rf+h9AIDfftmHlW+/jDVb96C0xow4rQr9b0rEqHsfwOD7 piBcG4UdmR/hwSnTnbpe47QqPP3YQ5g4+w2EhrvmwbqY+xuyNq3G1m++QdbhHJH4esVr8VTfIIxO rg+mOXXVgDtW5jvtR3MY1EltsRcDUKzOdxo5ZpweKzKLUcERUE7LgqT2BTB9P5/oF3YSvbg4FSGA ZF6mYVFC3+bcriUAhJdWzZLP3plH0pJjhf+PS08hP2xaTXjOTBry2TvzROc2fsVpVWTlgtnEbBaf 5y5l14rJygWzSa94cV+TdBqydpyO5M2NJ3FaldO+NPx+49JTyPKXZ5CVC2aTOZMzbK5r76VS0MJv Zu4X4fT35eJUNhowfT9fOlE7fHEu0b+RKO7g/a0CLkybF0MRw+z2Qh8fvCnM5sb0iteSlQtmk6qq CrviWTR7klMxLJo9iRgMhmYJ1B5H/vcdGZeeYiMiR31p+Jo5Jp2UXSu2uSbP806/j/VV/HJHyz0d FtX0YHB/K7FY30gk3ooDaPYc1Zy9EDb+/J3S8NQIMBTMQyJFnpRH+oZDpbB8/bTkWOzeshaHz1/D lBfegkYTKjqdEIK5U0ZitoPV/7j0FJw8k4Nn3loFpVJp95jm0HPgEKzNOoqcE4cxLj0FAJqck2rV LHZvWYslmVkI10bZvE9RFJ55axWGpya51AfKhbUGs7PEth5A9kKXrt8UzRIql7OT8H/sFbWxP153 3VjtB0iUEsZH2womlKIqDlM2FGLg/11Ct9gI7N6yFrtP5CFtxDj75xOCaaNuxYJVW2zei9OqsPO/ K7E26yhax8X79HsAQOfkXlibdRQ//7AFveK1Do9L0mlw9MQph9+pIa2ibUVsRatmEWoNPjE0LVSq 3Az2R3EsBf/HXq/UA/BYqHbz80tNFh+xROATNTA+UT/Jzz5Xg/4f5GPjySosmj0JB3KLmryZ00bd ipVbfrJpn5oxAKcuFOCO+6f4pO/O6DtoBA7kFmHR7EnCU8FKkk6D/x05g7iOCU1ep7K8DDt/Ouzw /VvjGyyOLrnmRGD+dx1UqUnU5o16AB4b/KXkz7cH1zMM5lExFsM4R7BwVykW7CpFnFaFAz9m48a+ aU1eY+6UkTYi1apZrF6xBHc/ON1rfa2ursTh7G04ffQgcs+eRnFJCSprDHj1nf9z2E+GYfDMW6tw 2933455RIwVvVP8+NyFK17bJz6wsL8OIAd2derHu7V43BTLwoK+4mNwYgDgAh/AVV4l+UbJo4myc 2CbwC6a6l7lfhNCv4pc7kkGd1AQASUuOJUVX811awNhbaKQlx5IrF897ZYF05eJ5smj2JJKWHGt3 YbRo9iSXr1VRdp0MT00Szh2XnuJ0UbdtzTKSpNM4XUQl6TSk8rUbLAupUTFu3wPjxDbihdWiZMJX XPXvKGbcOkvcidduIHyUMuACbSzS3Oc6CDckLTnW4Wq+MRs+XGhz4+ZMzmi2yYnnebJtzTKRqOy9 0pJj3b622WwmUzMGCNcYnpok6u/Fc2fJ0rnTXDZL/fh4bP29DWfdvg98lJLo64QuDGZbZ3ksVLeN sXb9+T9dl0TwMNczTMiUzCszI31lAfJK9egVr8WeE3/arObt8cuPO9E/fZiwqvbGo57wHD5f8gre fHuxTVCMPY787zsk970Nl86fQcGfuTDU1uJ6cT7CWkRBHRqOFjGt0T6xu13rxItTRwkLv+GpSWgV HYW9h361+7lJOo3d9rXjdIJjgc26BsbDtHbzsChRHAAAKMavhSdxAG6dIGV/Pp+ogelBHcBQKKri 0P+DfOSV6qFS0Dj+y0Eh1tQZ14qLcFNiO2HelqTTYMO2nU5jAZrimy+W45X/vOQwAssejgTUmDit CvFtonFj1wSk3zUSt436FzSaUDw5djCWrv+hyfNX3tsSt3ZU47PD5fjwgCUreM3Ylhh0gyXQhc6t aV62rRfjANw62Hx0PTF/N0/Uxm4sDHgpcxLOwvhUOyCIRqWBx8AVV4UbvfzlGXj8P0ubuIJlNMro 3xXb9p8BYLGtfr3nV7s2SFc4f+Y4npoyVrieP1ApaAzunYBHHpuOzNUfY90Px5wePz01Au8Mt6SU mDgCvZkI5ig6twaKzIJmD0ANn3JW2DtfBdtjjG+ESmrLiPGjO0Fq6utmSsKfz1AwPtpWMEE1DI5O S47FruMXQVFNf823n50sGPTHpafg028PemS85zgO777wCOYt+czrgSLuEKdV2V3Rx2lV6BRJIzFa iWFJGmH0bIi3i2zYxAGoI6F85Du34gBcNk+Zf3pPJFJAGvX2zUMihR9hftY1UQT/ko8+d0mkB7K3 Yt6SzyzXmD4GL76/zqXzGpN78gjGjxzi1mPeVzQWaa94Lb4aG+EwYJsqNQE1HNhtxV5PZ2e3FQtZ FgBAaq65XQ/AJYO/lPLzG8LHqcClWiKTss/VYEGDSf/UjAEu2Uory8vwwP0PQG/i8dk78zBvWaZH Iv144bO4sefNkhCpPY5cKMXJq2JbKFVqAn2qyrIY/u9VKJdf8sk99UY9AJdGVEn68+tyhcBQqDTw eGxz/WivVbNYuHKjS5d5+qERKKo0YvMnizFy4lNud6O6uhKPjBzY5HxQCjyzvQxHZ1ge9cyhcrCb i/z22czOEtt6AG7EATQ5okrVn8/1DRcqn7z8/TXRo+7Jifc2mWICADsyP8KmrJ/xzfpPPRLp+TPH 0buT7i8hUsASlG2t9ML1CHMcDO0DmhsH4LSnxGyQpj9fRYNLswRlnLpqwPIG+3hq1SyefP2DJi9R WV6Gp5+ehW+3bsKge/7l9Fij0Tbna++ODejTq5dLZiQp8e6Buse/ggLXM8yvn+0wDsBsaFKsToXK HfxYkv58LjVCsM0918jR0DI8CCMGdEeX1iHYu8NxOsSSuY/hkzXr0HfQCKeftWfrOky862ZR2+rF L2FwxhifRdb7kiMXSoXUFuv83m/YqTBOyi+DO/hxk6c6FCpfcVWS9fZJCANzXSpv9rkamzz9MwXV 2HPyEnp07SSklzQmNycHw+5/uEmR7sj8CEPvnYDv9p8Cx1nm6K8+MRYPP/1qQE1PzeXTwxa7N9Eq wMc5LmTsCxzuC9BEHIBDoZr3SLPePjewhTAh/8/uWrvHaNUsFq3a5PAaHW+4AT0HDnH6OdlffY57 HnoMehOP0hozTh3+CU+OHYyXlktjE9vmsO1s/X0lsf4VKuBgX4A9zvcFsLvql2J+PgCQKKXIHOXI FPTmi085DWRmGOfFHw5kb8XdYyaKRs2x99ztdD46PDUJwybMQLt27dC6dWtUV1fjxIkT2LZtK3Zl 7ZTUCJxXqkdemRlxESz49sFg9pU1fZIXsVsP4LdtTusB2DRK2Z9vLSFj4gj6LC+wKxx3vFH2OH5g D24fNNjl+Wdyty548623MXToUIfH5Obk4KlZT2H79h0Oj/E31sATqtQE5aI//d8BN+MAbEZUqebn 84kaoSrIJ4cr7IpUq2axenOWxyLNz7uAEXcNdVmkw4YNxfp165pMh+6ckIBvv92OJ5+ciaVLvVOh OU6rwo2JHdAqOgrRURYLSHV1NS7kXcG5P/KatEbs/7MWo5NDLHlkDOX/BbK9fQGc1AMQCZXXVxKT ROrti1DRFuM+LDlPr2TZf+SvWPyqSykY9qiurkTGbb1drtuU3K2LjUg5jsOGL/+LAwcPIjExCRMm jBeF4i1ZshS///67xyNrr3gtHhg9EvdNmYV2nbs6PfZacRE2f/w21maux56TtvEY+RX1f4ykhSIg 0zq7+wL8uAS8vpLQqlDHo41U8/NNo2KE/ozqFmI32HdqxoBmBTQ3Tkdu6rV9+3bRNTLXrSUx0VGi Y7RqlnzwwQei4/Iv5bmc6mx9pSXHku3rVnj8/Y79vNsmWLtXvFYS99jVegDCql+y/vxEjais+eZT VTbH9IrXYtmXTcdfOuK1f49zy7uU3K2LaE66Y8cOTHxoAoqKxTZdVhOB0aPE+2vp2sZi2uPiStzO GJ6ahOnTH4dBX40D2VtRcNn9aLUb+6Zh677T+GHTaqF0UHVtvd+f7xu4vQjcjgMwrp8oVvZ8z1IQ vPniw1miryuAkDc3nmjVrM1oo1Wz5OK5sx6PNps/WezW6AaAzJw5Q3SN5G5dbI5RKWiyb98+u5+5 fft2tz+z8XdOS44ly1+e4XYOlzW/SpRu4mKBCZ/e5/mN0lbWTxQJlQYc+PP3lAbWn89Qloj9Opvp xC+v2ixyVAoaWzau83heeiB7K8ZOe8bt8xIT64s2FBcW4OSp0zbHTHv8CaSmpto9v2N882oAlNaY sefkJUx/+T20adcR4wf3wPkzx106NzQ8Aht3H8Pg3gm4Y+WVei/VgBZ+d6laocrNYPeI1x2N4wBo qfrzzaNbOowztbLm/dcdep+aIvfkEdw1YrRH9s127doJ/86/aj8C6cLhLDz55Eysz1yHHTt2oLiw vtxlpLaF3XNcRatm0Stei7TkWKQlxyL3Qh6GD+qH1Ytfcul8pVKJjbuPoW9iG9yxMh9FdeXPzRkx ILqgZvXNU5qKA2Cl6M/nbteKyiousJNctmj2JNw77XmPrp978ggGpw3w2Fd/8eJF4d/tY9vYPWbb /jPA/jOwJsFs374dQ4fqAADXSt0fBIanJmH06Hsx+N6HHTozKsvLQHgOFO3coQFYxPr1nl9xS7f2 uCezDLsnaaFQWIoDK9/L8//9d1QPoC4OgOaOrBEdT1VxAfXncz3DLJWWYdmfdEJmoc0x86ePwTNv rfLo+laRNqd8+Nmz9XlQ4dooDBvm2NgPADHRURg0aJDw/19//cXlzxqemoScE4exdd9pPDRrvlOP W2h4hEsitRKujcKGbTtx6lIZnq8L7iExSpiHRLp8DW9Cn6222dzCqk+a6TVB9AYJYcAniovd+gs+ USMYgIuqOAz/rNBm1JszOQPzlnm2WezxA3uaLVIAyFy3TghSAYAP3nvXprROQ5YuXSrKv1rzxRdN foZWzWLDhwuxdd9plzJoPaVrz3748I25WL6/TNhCkxvQwu/BKoDl/pNGqTJWfdLMzVNAhYtLwJiH R4s2EPAHXM8wy+IJlg0bhnxSaCOoOZMz8PrHX3t0/QPZW3H7oMHNFikAFBWXYOXKlcL/4zom4PjJ 00ju1kV0XEx0FDLXrcWYsfX1rY4fP96kwb9XvBa/Hj3m8dTGXR6aNR/DU5Pw2OZrwuYYVgeL32Ao i+4aQIW3BXOzpbYXBTjeZc/TwgPuwvWLEHaCqzTwGPr5dZuAk/nTx3g8ku7I/EiIhPIWMdFROPbr r9C1jRW1V5aX4eRvp9EhLtbmPY7j0COlu10rgZU5kzMwf8WmJgNnvE3e+RwkJHXB5N5hQgq1P1Ph udu1wpTPiuKeZbDuBkgDAJMwhKI79BcdZE7TWjb28iUMBfOwKEGkRVUcBq64aiPSlQtmeyzSjxc+ i2Hjpnk9eqmouARDht6JynJx5FFoeARSU1NtREp4DiNGDHcoUq2axfZ1K/D6x1/7XaSA5akw55H7 sepwBXKKLe5U7s4ovzxZSTgLc5q4jCbdoT8ablkp/IMvziXGVSPQMInP6W4YzUVFwzRWJwSaNCzB IxyioLHhk/c8KqdDGpW38RUx0VE4tHePU997ZXkZ+vXv51Ckw1OTsGrDTkS3jrX7vr+orq5EXIwW t8arkDneMg1jvyn2eRig+f5WgpUHAEAxUE7eCjq6s6BPYQVAR3emmJvEtUK5HqE+mVTzcSoY/x0n iPTQJT36vn9JJFJreUhPRFpZXoaM/l19LlLAMrK2T+iGR0YOROHZQ/XB5pwRxfmX8H+vzERYRAu7 Io3TqoQFU6BFCsBSDmjivdh8qgqH6uqhcmlan46qfJxKLFIAzE3jRCIFGsWjWqOnfFYNhaHA3doC 5tvrv/yaXyrw7y3FokdzWnIsvsw6iOiWOrc/4vyZ4xg+qJ+kk+5UChqz/jUcz7/zmcs7pviL4sIC xMW2xdAEdf2o6sO5qr0qKoppWWgcPSWyqdCqUIoZ+KToQqStyiuuNWuJcvPgSCEXf8qGQkzdWCgS 6fzpY7Dr2B8eiTT7q88lnRkap1Vh/vQxyLt0Ga9//LXkRAoA0S11mDCsHzafqkJemcU0yHdvugqi J3A9w2x2wmYGPmkjUsAfEf7WUTRNK+wdf+iSHtM2l9oIyrrbcYhGg9DQECQndUaHjp1xyx0ZTVbU e+/FRzHz9RXu98/HJOk06N/nJjzwrylIyxgfkIVSQ3ZkfoSdWy3ByRqNBi1btUJi9164OX2kUBDO ulvhnNu1eKluJa584w/vxn64GeFvd/LhtRqo1v06u9Vv4jU/65pdl2hTxGlVGDKgN6bNmitKzGtu pRKVgkbfxDZI7XMTOnfpjo5JyQhtEY0IrcUSYTDUovL6NdRWV6CmshwV10tQVlqKmuoKlJeVQ6+v RXV1/R9cZGQUIqNjkJDcE937DfboyeBLivMv4dZeSXafOr3itbjjtgGY9PQr6NOrF0JULHJnW+bO 3l5UuVs71eEs2bh1FuF/21bf4MEu0Q1Xc45GUU/oFa/FonffR+sOnTFySJrb11QpaNxza3eMfWgK 7rh/qk+23JEy+XkXkJyUgNIaM0Z1C0HrMBa7/jCJfkeVgobexOPIzDh0axXk1a3s7e5K3XU4lCMW O9Sjwzf4iqvEuGKwKGXanc423H7cV/t1Wn9MV0nSafDopAfx0KzXPK57+nfhmy+WY/iEJxCnVWHv Y60RE8Igp9iIb89U48ODVYIFRtgSnSMIeu2CV3LnrEmaAqwKymlZoMNaOdSjQwc1HdaKYlMfFbXx ndUuxwGYB1kMuEVVHCZkFrosqF7xWiydOw0//7AF504fQ86Jw/hh02rMmZwhRKdbcfWaacmx2LZm GX67UokZr334jxcpANz94HSMS09BXqkeb+62TMUSopWYNbAFcmfH4tvJbZCk0wj+fzAU+PbBzf7c hkmaVtjUR52KFGiikC8xGyzFexuEAVKlJigXX3QaBkZCGBjnWqJ83JmTDk9Nwpa9vznMIi0vLUF8 rM7l8LzhqUmYM/+NJiuieAtiqMKpvduxc+dO/LjvZxRcLYRB3QrDb+6Eu4YNxS13jQcVFNL0hfxE 7skjSOjeGwBwfFY7JETbToE2nawS6vk3e68GhoJxVjvRDopUeFtLUV82yKkWndaeotggih0kDowg WgW4W50H/jbsyEEXN9ICgIKrhSgpuOzw/TNH96PGhVF0XHoKjv28G1v3nfaPSM16fP3pu3jq4VHY uXMnlEoFBva7Bf363ITCwiIsWLUF/UY/ilaxHXAy+0vf98dFOif3ErasXLSnPkaWuqwXdupruJs1 36F5Iyp3awuRNgCAHfR8kyIFXCyNblw/UZyqYuChfPeiQ3NFw/lpj/fy3VrsWOvQ9+5xI3RtYmE0 GnDl0kXsP/Sr3bTfhoxLT8GcN5Y1a3MITygvLUF4eBjA2F+UFZ49hHnPPyNsrnbih/8iedD9/uyi Qw5kb8Ut6RlQKWjkPtseMSEM6FNVYLcUgRsWbeM1CnrlvEfz1Ib7LFihO/SHcsynLmnQpYPcjQMg uiAYZ8QBAMauLbCbOeptjv2826UK04Hk/16Ziekvv4eY6CgU5p0DVOF++VyO43Dq8E/448xRlF+/ jsiYlkjq2R8dk24EAHRpHYIzBdVYmhGDaX3DAROxCJIj4ONUMA+PFgzUxYyAAAAOQElEQVTzitX5 HgXWu+LPd4ZLlVzdjQOgioyAyTKHTetou5mBt0nSaQIq0vy8C3j1ibHo3TESwUoGkRoFeneMxI7M j0THPTZvMZK7dUFRcQlO7tvpl77NnTISMWEqpNxyG0ZNmoWHn34Vwyc8gRu6pKBdZDBefWIs7rj1 FgDA1tN1A4qCAt+pbgufPD2UH14Gu7EQMPDgk9wPqnfVn+8Ml0sOMwOfAqUWxws2DnQV4AjoPyyV 9kZ1C3Ea/e4NZv37cZ9e3xHFhQV4cuxgdLyhE15avh6nLpWhb2IbdO+ow6lLZRg2bhq++WK5cDxF M1jwnKWvOecu+Lx/33yxHAtWbREtPlUKGlo1C5WCRl6pHi8tXy/sSbXvTz1MdYtk0rpBkh9HwPxS gaA3/rAMQm5iExCtjgQ7YIZb13BZQe7GATA/W7wYMSEMXkp3vGV3c5k5Jh1TXnBestAXbFzxBhLj 47B0/Q/oFhuBDR8uRHlVLXafyMPuE3k48GM2VAoazz77nOi8djrLTWsd3bxM1KYouHwJ02fWp4LH aVU4PqsdyuZ3RP68Diib3xG5z3XA0owYJOkso6TexONoviV9mm9nZ+Gk5932Tjny57uzdQ/g5jbo zI33gWopTrfg7oyyWwu+YcHWf/eLwKhu3jXLaNUsVi6YjSWZWV69blOUl5Zg/OAeuO/RFwAAn70z D4fOleDeac+LPFw39k1D38Q2NgvJynLL6rpjlx4+6yPHcRg3rJ8obHLhnS1szE9xESym9Q3H0Rmt sTQjBioFjaN1u0iLRlRPUdEWfTSAatkFzI3up7i7JVSKZig2fa6ojYQwlrA9O7DbigEDDwVDIXO8 DkszYqBVNy9rIE6rwpzJGTh7Ic/vI+neHRvQvVOsEFcQomLRrVc/u3bf6upKnDhfYOOk+Hb7DkzN GICWiX180kdCCB4bfZvIQvLgTWGCmYk+VQV2YyHYb4pBn6oS7OHT+oZj7+P1uXMkhLFJtHMX8+1a m2uw6XPd3l4ScFOoAMDE9aHorsNFbVxqBEiUrWmGKjFC8ckVIQV2Wt9wrBnrftJYkk6DqRkDsH3d CvxeUI7XP/7ar8EexfmX8MjIgRgw7H7kleoxf/oYLH95BvJK9eifPkw0D7WyYOYElNaYMWXsSKGt vLQEJ8/kYsUax3sLNJcXp44SzGCA5Q/73RGW6QZVaoJikyW2lNlXBsXaAigX/Sk8+bq1CrKs+uto /Mh2h4ZFl63QXYd7tGEv4MHu0oD7cQAkhIH5vlaC6+zpbcVYvr8MWjWLxa++AF3bOBRczkN5aRGM RhMiWkQiQqtFh6Qe6HzjzQGL2ywvLcFbz07B4s+3QW/iEadVYfWnq5A2wmIBaZg0uHTuNMx4zbLn werFL+Hhp19Fkk6DY3+WClOCwrOH0LJTikN7a3Owl3qjUtDY+3hbdGtleYwrPnC84RnXLwLmoeIc qeZETHniz/cJ5n3LbUtUJmocF8NiKGJ4qh3RL+xEKl+7gTx4U5hQ9Gv+9DHEYDB4UuPMJ1y5eJ7M mZwhFGVTKWgyZ3IGqaqqsDn22M+7SZxWZSmeNiadzJ8+RihklnPisF/6azAYbMpmqhQ0+XZyG+He mG/XNl2sTBck3CP9wk7EdH8rz0pJJmpstGHet7xZpVc8Vjcx1RLjymFuxQGQKCVM09qChDAwcQQL d5UKcQBJOg2ee2YWxj7xYkDC7oxGI7I3fYYPli1B1uEcUcDLzz9sceqKzc+7gPS+3YWFU5JOg693 7vFp4YiGnz3+7jQbr5219DngZpImQ8E8Ihpcn3DP0pAc+fOnbgelCPbvaGqFy9lp+5fTxF8urwsi hrnxwvHfTm5DknQaYSSI06rInMkZ5Mj/viM8Z/bpSFRVVUG2rVlGpmYMsClpOS49hWz4cCFRKWiS lhzrcMT/afuXoiK5UzMGkIqy6z7tt5Vta5bZ9FuloMnacbr68o0T2xDCUB6Nioa58W6fa75da/uk dXF3Pmc0W+HuxgEAFr+v6UGdMFk3cQTrj1Vi8b4qkTlHq2bRL6UTBva7Bd173YLk1CE2+fLucK24 CL/s3oqDP2Zj14/7cODsFdHIGadV4cFRQzDthTeFUpY7Mj/CsHHTMC49BV98/ytKS4px6IevsXPr Bmz+fq9gAkpLjsXCd5f5JQimvLQEjz8w2CarQatmsWZsS2Frc+qyHspVVzyOISXhLCgD7/L5zfXn O6PZF/C4HoCdjFTAkgnw32OV2HZWb7f8jkpBo0NUMFpGaREaGoJQdRCio8S2uppaA6qrK1FZY0DB 1UJU1xpQWG5wGB5oFWiP3n3RIro1amsqoa+uRFlpKQquXELmV9twpqAaWjUruoZWzWL04Fts0mN8 BeE5rHrzBTz32rs23yVJp8H6sVGCrZTOrYHi83y/VuVrrj/fGV6ZM5i+n0+4X8RVAZ2tMBtCwllw Q6LAdQ+xyR/PKTbiUJ4ex/INOHiVRlFZjVdqR3mKdSeSgf1uQf8hGeiddpcoWa+6uhL7vv0v7rh/ ilc/lxCCLZ8twZy58+xGok1PjcDLd0QitG4kY45Wgt1U6FeR8nEqmB4TP+2YnhOguOMlr2jMKxch tWXEuGIwSG29KcPdiTgJYcD3CQd3Y6iwa7Q9TBzBhVITyvU8Kg088htMMWpMBGoFBbXScsMigmmE BtFoFcpCxVIoqjKjsIpDWS2PkmoOhZVmlOt55FeYcfYaEUQwPDUJI+6+GxFaLaJ0cYjt1BWxHZMc LvKMRiM+Xjgby1aswoZtO70WZlhdXYnVb7+IZStW2RVokk6Dt4dFCI96cATsjhK/b3AG2MnPD46A clqW265SR3htFWY+up6Yv5snavO0cAGJUoJPUINvHwzSOsgm2NYXmDiCkavzhcrW49JT8Oyr7zqN yirOv4TVS17G+6vWoajS6HH5oYYQnsO+nV/h8xXvY1PWz3anK3FaFebdHo4xKaFQ1D2FqCIjFOuv giow2Bzva7ieYaL9ogCAvfNVsD3GeE1fXruQL3f8IyEMiFYBEq0EwlmQcBZEzQBKGkRdN3FX0gBL AWYCGC2fR9XwgJEHVcNZItZDWBANYzlHzYBoGNHEv7HJDLCIov9NiWjfrh1aaCNRW1ODszlnkXsh T1TMrVe8FtOmTMZtI8cLcZ4ufTdCcOHsCez+ei1278rCd/tPOZxLD+qkxqTe4aKoe3AE7K5SSyn7 QFQJdzM/31O8atfyWj0Af8JYYi9NY1oJos0pNmLRnuvYeLLKYQKhSkFjaIIarcNYm4WfVs2ie0cd WreMRHRUFDQaDVSqYASr1bheeg3V1dUoLilB7oU8XLha4TQHLEmnwYSUYNzbPRRxEQ3iJOpC75hd gd0UxN38fE/xugHWuHkG4c82KFTrQT2AQECilDA90FI0zzJxBEfzDcgpMqK42mLViNYwSIhRokfr IOGxCwCnrhrw1ckqfP8nHG4m7ApJOg166hjcGh+MWzuqxeIEAAMP5lA5mH1lgd21Bg7y8xOHQjnq Pa/ryusXbG49gEDD9QwDN7CF0wVdU1QaeBy6pMfxfANOFxpRUGlGOadCda0BrUMsj+ewIBqtw1iE q2h00CqQEKNEUoxSWLmLO0VAn68FfaISzLHKgG4E0hB/+vN94tIy71tOzD8uEbV5mmsTKPg4FcgN avDtgkEiWEBdNwcrM4EqM4MuMIA6VwOq3Ay+Wwj4zhrwHYO9VqKRquJA/14D6nwNmN+qAr5pcmMa JnBaYQc+CbbfdJ9oyicX9SQO4G+BigbfPhh8fDBIyyDw7VSixZpdDDyocjOoIiOo6ybQF2pBFRgC /lh3SgD8+T6pfU4pgqnG+wJY6wH4a1+AgKDnLZkNDZ4cJIQBQlmQukqGVF3SI2o4S5zuX/AP12F+ vg+DTnyWdcckDKHouJtFbeaBLZodNf5Xg6riQBUYQOfpQefpLaOldcT8C4qUhDAwDxSv8um4m0X1 9n2BT9ND2TteAqgGwgyiwQ1zkLkq85eAGxYtns5QjOU++xifCtWf+wLI+B5v5Od7im8T7gGwA2aA ChankjisByAjaWzy84Mj3M7P9xSfC5UKjqCYATNFbd7aF0DGf9jNzx8w02tBJ03hc6ECANNjLKjo BFGbo3oAMhLEXn5+dAKYHmP91gW/KIWiGarxhNtZPQAZaWE3P/+Ol7wadNIUfhvSmLg+FJ0o3i7c UT0AGelgNz8/cajXg06awq/PXva2ZwG2wTzHzo7CMtLCZqdxVmW5j37Gr0KlI9o2a18AGf/isN5+ RFu/pz37fTXD9JkEKrytqK1xhQ4ZCcBQlvvSACq8LZg+kwLSHb8LlVIE2+4LEKME19c/1ZdlXIPr G24T6uhrf74zAmIfshsHMDjyHxcHIFVICGPZs7YB/vDnOyNghkw5DkC6BMqf74yACVWOA5AmgfTn OyOgriE5DkB6BNKf74yAClWOA5AWgfbnOyPgznY6ZYwcByAFHPjz6ZQxAeqQmICrgWZYOQ5AAjjy 59MMG/DRFJCAUAE5DiDQSMWf7wxJCBWQ4wACiVT8+c6QjFDlOIDAICV/vjMkI1RAjgPwOxLz5ztD UkKV4wD8i9T8+c6QlFABOQ7AX0jRn+8MyQkVcBAH0OhHlWke3OBIyfnznSFJodqNA+gTLscBeAk+ TgWuj3g6JQV/vjMkKVRAjgPwJVL15zvDJ0XSvAEVHEGZf/mCmL9/RWizxgEwv1UFsGd/bbiuIZL1 5ztD0p3jOTMxfToSpDgn0F3520JFJ0Ax8WvJuEodIdlHP2A/DkDGu0jJn+8MSQsVsB8HIOMdpObP d4bkhQrYiQOQaT4S9OfLyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI/H34f4DnQZLCUbKg AAAAAElFTkSuQmCC "
+       height="18.421789"
+       width="18.421789" />
+    <path
+       style="fill:#455c91;fill-opacity:1;stroke:#485c90;stroke-width:0.065px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 13.984312,12.726634 0.03325,2.630469 c -0.626212,1.348342 -1.864809,3.416425 -2.757403,4.184964 l -0.113641,-0.140573 -6.1504829,-0.01206 c -0.316416,-0.01349 -0.654604,0.350565 -0.635432,0.60017 l 0.605343,7.881219 c 0.01985,0.258488 0.294567,0.581835 0.581835,0.581835 l 5.4774769,0 c 0.214377,0 0.508195,-0.213055 0.517186,-0.476047 l 0.02351,-0.687624 c 0.177836,0.252545 0.659175,0.628853 1.075513,0.628853 l 7.381664,0 c 0.924147,0 2.348823,-0.984515 1.880679,-2.644705 0.529304,-0.423588 0.842626,-1.143065 0.52894,-2.056992 0.555062,-0.453627 0.95877,-1.306413 0.493678,-2.068746 1.479159,-1.239472 0.519291,-2.973824 -0.622974,-2.973824 l -4.972045,0 c 0.185997,-0.813338 0.477909,-1.644292 0.458416,-2.738738 -0.01684,-0.945207 -0.644701,-2.322763 -1.093145,-3.056102 -0.187053,-0.30589 -1.913467,-0.895396 -2.712363,0.347897 z"
+       id="path3009"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccssssscsccccscssc" />
+    <path
+       style="fill:#6e7fb3;fill-opacity:1;stroke:none"
+       d="m 5.0692251,20.14975 5.1806329,0 0.0121,7.613594 -4.6117319,0 z"
+       id="path3764"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#6475ab;fill-opacity:1;stroke:none"
+       d="m 5.6260221,21.178614 4.1033522,0 0,6.124767 -3.5828682,0 z"
+       id="path2994"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#edf5f7;fill-opacity:1;stroke:none"
+       d="m 16.482302,18.888451 c 0.237198,-0.953632 0.410241,-2.014256 0.524972,-3.030803 0.0282,-0.249886 0.02697,-0.465789 -0.01088,-0.672916 -0.149763,-0.819429 -0.492693,-1.551175 -0.814688,-2.288077 -0.318932,-0.250948 -0.943214,-0.350861 -1.411378,0.02979 l 0,2.586337 c -0.785404,1.538476 -1.671195,3.019589 -2.765007,4.381833 l -1.031019,0.719827 0,5.987243 0.714095,0.0028 c 0,0 0.946752,0.578944 0.99646,0.55409 0.08285,0.04142 7.381163,0.02059 7.381163,0.02059 0.395654,0.0082 1.82301,-1.034467 0.913858,-1.848307 -0.121149,-0.07432 -0.105237,-0.297756 0.0083,-0.372073 0.568248,-0.102002 1.256969,-1.17096 0.537522,-1.733988 -0.122527,-0.136544 -0.03468,-0.350662 0.110298,-0.366631 0.425004,-0.205227 1.152864,-0.892181 0.492078,-1.721683 -0.13333,-0.0679 -0.13908,-0.24295 -0.01515,-0.348641 0.639145,-0.08914 1.448755,-1.545236 0.108634,-1.89517 z"
+       id="path2987"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssccccccccccccccccc" />
+    <path
+       style="fill:#dce4e7;fill-opacity:1;stroke:none"
+       d="m 11.500825,26.603743 0,-6.359462 -0.528281,0.358422 0.0024,6.000473 z"
+       id="path3002"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#dce4e7;fill-opacity:1;stroke:none"
+       d="m 15.460842,12.670845 0.613058,2.64244 -1.623773,2.883025 c -0.168273,0.29877 0.03515,0.601651 0.277532,0.613058 l 1.760469,0.08284 c 0.268792,-1.21509 0.593159,-2.696958 0.527037,-3.612067 -0.120278,-0.638095 -0.379047,-1.44522 -0.833741,-2.393188 -0.253938,-0.172262 -0.464918,-0.216113 -0.720582,-0.216113 z"
+       id="path3000"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccc" />
+    <path
+       style="fill:#dce4e7;fill-opacity:1;stroke:none"
+       d="m 19.967851,18.884443 c 0.576951,0.54845 0.230529,1.581917 -0.27675,1.947465 -0.09622,0.0555 -0.11695,0.192137 -0.04686,0.281187 0.559147,0.639226 -0.184326,1.716857 -0.421781,1.827717 -0.07698,0.06918 -0.08661,0.149591 -0.0703,0.234322 0.636824,0.892478 -0.09901,1.635413 -0.351484,1.804285 -0.08352,0.07488 -0.109404,0.204568 -0.04686,0.328051 0.555499,0.87442 -0.08777,1.493624 -0.454649,1.878505 l 1.812641,0.0038 c 0.348549,0.01747 1.811331,-1.045389 0.841892,-1.880176 -0.108877,-0.09376 -0.03864,-0.336024 0.0358,-0.349382 0.479935,-0.08613 1.327001,-1.100218 0.534201,-1.743525 -0.05537,-0.04493 -0.102552,-0.267797 0.108928,-0.361267 0.655022,-0.28951 1.059493,-0.985784 0.49944,-1.725413 -0.148962,-0.08391 -0.130345,-0.265904 -0.01336,-0.338019 1.094277,-0.325978 1.119441,-1.776095 0.103493,-1.903211 z"
+       id="path2985"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccsssscccc" />
+    <g
+       transform="matrix(0.065,0,0,0.065,4.3429681,11.929852)"
+       id="g3779">
+      <path
+         transform="matrix(0.59806884,0,0,0.59806884,30.309966,82.598928)"
+         sodipodi:open="true"
+         sodipodi:end="12.541589"
+         sodipodi:start="6.2585156"
+         d="m 80.03736,237.47695 c 0.188395,7.63513 -5.848379,13.97735 -13.483511,14.16575 -7.635132,0.18839 -13.977353,-5.84838 -14.165748,-13.48351 -0.188395,-7.63513 5.848379,-13.97736 13.483511,-14.16575 7.634528,-0.18838 13.976476,5.84746 14.16571,13.48196"
+         sodipodi:ry="13.828837"
+         sodipodi:rx="13.828837"
+         sodipodi:cy="237.81807"
+         sodipodi:cx="66.21273"
+         id="path3780"
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         transform="translate(-0.24218783,0.04882811)"
+         sodipodi:open="true"
+         sodipodi:end="12.541589"
+         sodipodi:start="6.2585156"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:ry="1.0498047"
+         sodipodi:rx="1.0498047"
+         sodipodi:cy="223.04004"
+         sodipodi:cx="68.334961"
+         id="path3782"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         id="path3790"
+         sodipodi:cx="68.334961"
+         sodipodi:cy="223.04004"
+         sodipodi:rx="1.0498047"
+         sodipodi:ry="1.0498047"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:start="6.2585156"
+         sodipodi:end="12.541589"
+         sodipodi:open="true"
+         transform="translate(3.3466792,0.04882811)" />
+      <path
+         transform="translate(3.3466792,3.6865236)"
+         sodipodi:open="true"
+         sodipodi:end="12.541589"
+         sodipodi:start="6.2585156"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:ry="1.0498047"
+         sodipodi:rx="1.0498047"
+         sodipodi:cy="223.04004"
+         sodipodi:cx="68.334961"
+         id="path3792"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         id="path3794"
+         sodipodi:cx="68.334961"
+         sodipodi:cy="223.04004"
+         sodipodi:rx="1.0498047"
+         sodipodi:ry="1.0498047"
+         d="m 69.384446,223.01414 c 0.0143,0.57962 -0.443975,1.06108 -1.023589,1.07538 -0.579615,0.0143 -1.061079,-0.44397 -1.075381,-1.02359 -0.0143,-0.57961 0.443974,-1.06107 1.023589,-1.07538 0.579569,-0.0143 1.061013,0.44391 1.075378,1.02348"
+         sodipodi:start="6.2585156"
+         sodipodi:end="12.541589"
+         sodipodi:open="true"
+         transform="translate(-0.24218783,3.6865236)" />
+    </g>
+  </g>
+</svg>

--- a/img/Twitter.svg
+++ b/img/Twitter.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="68.003784"
+   height="25.348675"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Twitter.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3785">
+      <stop
+         style="stop-color:#fefefe;stop-opacity:1;"
+         offset="0"
+         id="stop3787" />
+      <stop
+         style="stop-color:#dfdfdf;stop-opacity:1;"
+         offset="1"
+         id="stop3789" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3785"
+       id="linearGradient3791"
+       x1="39.280788"
+       y1="12.902368"
+       x2="39.280788"
+       y2="32.148937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32703118,0,0,1,0.75454017,0)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="9"
+     inkscape:cx="26.556664"
+     inkscape:cy="16.694151"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1344"
+     inkscape:window-height="1419"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-0.62121129,-12.484656)">
+    <rect
+       style="fill:url(#linearGradient3791);fill-opacity:1;stroke:#cccccc;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect2985"
+       width="58.957203"
+       height="19"
+       x="1.1212113"
+       y="12.984656"
+       ry="2.1487894"
+       rx="2.1487894" />
+    <text
+       xml:space="preserve"
+       style="font-size:14.40710354px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#333333;fill-opacity:1;stroke:none;font-family:Sans"
+       x="22.176807"
+       y="26.724609"
+       id="text4002"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan4004"
+         x="22.176807"
+         y="26.724609"
+         style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:#333333;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Bold">Tweet</tspan></text>
+    <image
+       y="23.166666"
+       x="53.958332"
+       id="image3353"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKoAAACqCAYAAAA9dtSCAAAABHNCSVQICAgIfAhkiAAAIABJREFU eJztnXl4E9Xex7+zJE2TbqQLBGiBIrQFikUWsSxWKSIoFMSFRa6yiYoXFMUFxKuooKIICq8ioiJC uQIioCDWAlcB2ZRVoBVQCrR0oXRvtpnz/pFm2mmWJmmWUefzPHkeOJmZnGS+PXPObzuAjIyMjIyM jIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjJehAt0BV+DLLhPjyqGAWR/orvx9YFVQTt0BOqLt X0IDdKA74Arm3W/JIvU2Zr3ld/2LIHmhcnmHCH92R6C78beEP7sDXN4hEuh+uAIb6A44g+fMxPTp yEB342+N+fv54DkzoRlW0lMAaQv12HqQ4hxRG7uxEMxvVQHq0V8frmsIzPe2FP5PinPAH1sfwB65 hmSFSmrLiHHFYFEbdVkP5peKAPXo7wHzSwW4vuEgbVVCG/fTUpDaMkIFR0h2VJXsHNX803sgtWWi NnZbcYB68/ei8e9Iastg/um9APXGNSQpVL44l3C/rhO1MYfKQefJK39vQOfpwRwqF7Vxv64DX5wr 2YWVJIVq/n4+QLj6BgMPJuta4Dr0N4TJugYY+PoGwll+d4kiOaFyOTsJn3dQ1MZmXQNVxTk4Q8YT qCoObKM/fj7vILicnZIcVSUlVGKqJebsN0RtVJERzIFyB2fINAfmQDmoIqOozZz9BoipVnJilZRQ uUOfgJRfFrWxO0oATnK/298Djlh+3waQ8svgDn0SoA45RjJC5csuE/P+D0VtdG4N6LPVAerRPwP6 bDXo3BpRm3n/h+DLLktqdJCMUG38+RyRzVF+gt1WLH5qSTAOQBJCtefPZ/aXgSoxOjhDxptQJUYw +8U2a6nFAQRcqDxnJo3NIlQVB3ZXaYB69M+E3VVqY1mxxgEEqEsiAi9UO/585rsSQM87OEPGJ+h5 y+/eACnFAQRUqKS2jHA/LRW1yf78wMH8UgHqstj7Z40DCFCXBAIqVNmfLz2kGgcQMKHa9ecfrZT9 +QGGztODOVopapNCHEDAhGrXn79dHk2lALO9WHJxAAERquzPlzZSjAPwu1Blf/5fA6nFAfhdqLI/ /y+CxOIA/CpU2Z//10JKcQB+Farsz//rIZU4AL8l93F5h4hp7XhRmxT8+SRKCT5BDb59MEgEC6gZ yxtmAqrMDPpiLegz1aAKDAHtZ6CwxgFwA1oIbdY4ACauj9+SAf0iVMJzxPhJhqgt0P58PlED8yCt KBuzMSRGCb6zGhgcCeqyHmx26T9ymsLuKgXfIwwkhBHazN/PB+E5QtGMX8TqF6FyRzOl489X0TCN bgm+W4ioOafYiFNXjSip5lBt5BGtYZAQo0SP1kFQMBRIWxVMD7UGc6gc7Nbif9biry4OoHE9AO5o pt+64HOhSik/n4SzME1qAxKjBAAUVXH48OcyfHigAqU1ZrvnaNUsxqaE4LnbtIgJYcD1CQeJUEDx ef4/SqyBrgfg88WUZPz5Klok0jW/VKDzW39iwa5ShyIFgNIaM5bvL0PKu3nIPmdZAfOd1TCNaeWX bkuJQMYB+FSoUvLnm4dGCSJd/ON1TN1YCL3J9alHaY0Zd626gk0nLeWE+G4h4PpF+KSvUiWQcQA+ ffRLxZ9PdEHg+oQDADadrMKcRoZsd5i8oRDdWimREK2EeXAk6OOV0nX9MhT4NkEgsSqQcBYIYUEU FCgTAUw8qCIjqGsmUJf1Ln8HZnsxuC4aIKhujPNTHIDPhMrl7CSmr54Qf1iA/PlcX4tITRzBC99d b9a19CYes7YV49tJbYAgGtzAFmC3ey58X8AnasD1DAOfoAEUrk0fqct6MGeqLSkpTha51jgA893R 9Z9XFwfAJAzx2VzVJ0IlplpiXDlM1EaVmgLmz+e7WFb4W09XI6/U8bRDq2YRomJRVGl0Oi3I/r0G 2edqMOgGNfgeYYBEhEp0QTDdE2PX5FZUxeF6LYdyPQ+1gkKYioEulIGizrpE2qpgbquCOU0Ldk8p mP9dd7hYZA6Ug0uNANEqhDZrHAClCPaJWH0iVLv+/MYeDj9BopSC/W+HAxvouPQU/GfxSnRO7gUA MBqNyFz2Gh59/nWHgs08WolBN6hBQhhwPcNAVXMgkQogiLY8ZhU0iJ3RjKrhAAMPqtxseeyWmy3B H838bbh+ETAPjQLqhFdUxeGLXyuQfa4GR68Y7S4YVQoa3WIjcHMrHg+khKJPrApQUDAPjgSXpIFi db79J2CdR9H0UGuhyddxAF5XP19x1WKOauAqpXNroPj0irc/yrX+xKlgeiwWAHDXJ1eQ/bvYdz1z TDqWZGbZPXfjijdw36Mv2H1Pq2ZxcU57YURqFhwBVWAAnW8AlacHfa4GVLljS4QIhoJ5dEtwPUIB AJUGHu/+eB2Lfypza7EIAEk6DVaM0loEC0tUm/KDSw6nAqaJbSwOESusCsppWaDDWnldV16/oHHz DHHqM0egXJIXMFcpn6gR/vJ7vJePMwXiUbWkqBCR0TEOz+/dMRJHLtj3oB2f1Q4J0UpRW6WBx/Va HhV6DjUmgsoGAcihQTTCVTRaBDOIaeDlsQdVZARzvNK5+5ahYPpXa0Esp64acM+aIqfTG1dYMDQK swZaXKbM0UqwX161exyJUsL4ZJwwigMAnTgUylHveV1XXn30S9GfT5WYhH/31DE4U1D/nkpBOxUp ADwweiSOLLL/SPuobs59ttiI/CoKf5TUujyKqRQ0YkKV6NmaRVKMEl1bBWFAh2BBwCTGYlWwum+Z Y5UWJ4l1dGMomMa0EkSafa4Goz8vcHsUtcecHSVo10KB0ckh4HqEgj5QZtek6M84AK9djPAcMX52 D0jh6fqLV3FQvvNnwFOfjXPjQUIYbDpZhfHrCkTvnTqyF1179nN47p6t63BbxniH77uDK4u1JJ0G t3dQYFiSBgM7BIunFgYezKFyMPvKwA2JEh733hRpw77mPNsOoUG001EVKhrGp9uL4gColl2gfPgr eDMOwGsGf+74BpFIAenk59OnLUb6EV00SNJpRO8tfdX+HJTjOOzI/Agr318kak/SaTAuPQVTMwa4 9NkqBY2pGQPww6bVKKrQ4+K1WtQaOeRfysMPm1Zj0exJGJeegjitZV54pqAay/eX4a5VV9BuwZ94 elsxTl2te/QH0eAGtIDx+Q4+FSlgcXCsqzPuc91DAJUDqdirB1B4GtzxDV7tj1cUb/XnN3SVUpf1 UC6/5I3LN5uGc6nsczW4a5V4YffT9i/Rf+h9AIDfftmHlW+/jDVb96C0xow4rQr9b0rEqHsfwOD7 piBcG4UdmR/hwSnTnbpe47QqPP3YQ5g4+w2EhrvmwbqY+xuyNq3G1m++QdbhHJH4esVr8VTfIIxO rg+mOXXVgDtW5jvtR3MY1EltsRcDUKzOdxo5ZpweKzKLUcERUE7LgqT2BTB9P5/oF3YSvbg4FSGA ZF6mYVFC3+bcriUAhJdWzZLP3plH0pJjhf+PS08hP2xaTXjOTBry2TvzROc2fsVpVWTlgtnEbBaf 5y5l14rJygWzSa94cV+TdBqydpyO5M2NJ3FaldO+NPx+49JTyPKXZ5CVC2aTOZMzbK5r76VS0MJv Zu4X4fT35eJUNhowfT9fOlE7fHEu0b+RKO7g/a0CLkybF0MRw+z2Qh8fvCnM5sb0iteSlQtmk6qq CrviWTR7klMxLJo9iRgMhmYJ1B5H/vcdGZeeYiMiR31p+Jo5Jp2UXSu2uSbP806/j/VV/HJHyz0d FtX0YHB/K7FY30gk3ooDaPYc1Zy9EDb+/J3S8NQIMBTMQyJFnpRH+oZDpbB8/bTkWOzeshaHz1/D lBfegkYTKjqdEIK5U0ZitoPV/7j0FJw8k4Nn3loFpVJp95jm0HPgEKzNOoqcE4cxLj0FAJqck2rV LHZvWYslmVkI10bZvE9RFJ55axWGpya51AfKhbUGs7PEth5A9kKXrt8UzRIql7OT8H/sFbWxP153 3VjtB0iUEsZH2womlKIqDlM2FGLg/11Ct9gI7N6yFrtP5CFtxDj75xOCaaNuxYJVW2zei9OqsPO/ K7E26yhax8X79HsAQOfkXlibdRQ//7AFveK1Do9L0mlw9MQph9+pIa2ibUVsRatmEWoNPjE0LVSq 3Az2R3EsBf/HXq/UA/BYqHbz80tNFh+xROATNTA+UT/Jzz5Xg/4f5GPjySosmj0JB3KLmryZ00bd ipVbfrJpn5oxAKcuFOCO+6f4pO/O6DtoBA7kFmHR7EnCU8FKkk6D/x05g7iOCU1ep7K8DDt/Ouzw /VvjGyyOLrnmRGD+dx1UqUnU5o16AB4b/KXkz7cH1zMM5lExFsM4R7BwVykW7CpFnFaFAz9m48a+ aU1eY+6UkTYi1apZrF6xBHc/ON1rfa2ursTh7G04ffQgcs+eRnFJCSprDHj1nf9z2E+GYfDMW6tw 2933455RIwVvVP8+NyFK17bJz6wsL8OIAd2derHu7V43BTLwoK+4mNwYgDgAh/AVV4l+UbJo4myc 2CbwC6a6l7lfhNCv4pc7kkGd1AQASUuOJUVX811awNhbaKQlx5IrF897ZYF05eJ5smj2JJKWHGt3 YbRo9iSXr1VRdp0MT00Szh2XnuJ0UbdtzTKSpNM4XUQl6TSk8rUbLAupUTFu3wPjxDbihdWiZMJX XPXvKGbcOkvcidduIHyUMuACbSzS3Oc6CDckLTnW4Wq+MRs+XGhz4+ZMzmi2yYnnebJtzTKRqOy9 0pJj3b622WwmUzMGCNcYnpok6u/Fc2fJ0rnTXDZL/fh4bP29DWfdvg98lJLo64QuDGZbZ3ksVLeN sXb9+T9dl0TwMNczTMiUzCszI31lAfJK9egVr8WeE3/arObt8cuPO9E/fZiwqvbGo57wHD5f8gre fHuxTVCMPY787zsk970Nl86fQcGfuTDU1uJ6cT7CWkRBHRqOFjGt0T6xu13rxItTRwkLv+GpSWgV HYW9h361+7lJOo3d9rXjdIJjgc26BsbDtHbzsChRHAAAKMavhSdxAG6dIGV/Pp+ogelBHcBQKKri 0P+DfOSV6qFS0Dj+y0Eh1tQZ14qLcFNiO2HelqTTYMO2nU5jAZrimy+W45X/vOQwAssejgTUmDit CvFtonFj1wSk3zUSt436FzSaUDw5djCWrv+hyfNX3tsSt3ZU47PD5fjwgCUreM3Ylhh0gyXQhc6t aV62rRfjANw62Hx0PTF/N0/Uxm4sDHgpcxLOwvhUOyCIRqWBx8AVV4UbvfzlGXj8P0ubuIJlNMro 3xXb9p8BYLGtfr3nV7s2SFc4f+Y4npoyVrieP1ApaAzunYBHHpuOzNUfY90Px5wePz01Au8Mt6SU mDgCvZkI5ig6twaKzIJmD0ANn3JW2DtfBdtjjG+ESmrLiPGjO0Fq6utmSsKfz1AwPtpWMEE1DI5O S47FruMXQVFNf823n50sGPTHpafg028PemS85zgO777wCOYt+czrgSLuEKdV2V3Rx2lV6BRJIzFa iWFJGmH0bIi3i2zYxAGoI6F85Du34gBcNk+Zf3pPJFJAGvX2zUMihR9hftY1UQT/ko8+d0mkB7K3 Yt6SzyzXmD4GL76/zqXzGpN78gjGjxzi1mPeVzQWaa94Lb4aG+EwYJsqNQE1HNhtxV5PZ2e3FQtZ FgBAaq65XQ/AJYO/lPLzG8LHqcClWiKTss/VYEGDSf/UjAEu2Uory8vwwP0PQG/i8dk78zBvWaZH Iv144bO4sefNkhCpPY5cKMXJq2JbKFVqAn2qyrIY/u9VKJdf8sk99UY9AJdGVEn68+tyhcBQqDTw eGxz/WivVbNYuHKjS5d5+qERKKo0YvMnizFy4lNud6O6uhKPjBzY5HxQCjyzvQxHZ1ge9cyhcrCb i/z22czOEtt6AG7EATQ5okrVn8/1DRcqn7z8/TXRo+7Jifc2mWICADsyP8KmrJ/xzfpPPRLp+TPH 0buT7i8hUsASlG2t9ML1CHMcDO0DmhsH4LSnxGyQpj9fRYNLswRlnLpqwPIG+3hq1SyefP2DJi9R WV6Gp5+ehW+3bsKge/7l9Fij0Tbna++ODejTq5dLZiQp8e6Buse/ggLXM8yvn+0wDsBsaFKsToXK HfxYkv58LjVCsM0918jR0DI8CCMGdEeX1iHYu8NxOsSSuY/hkzXr0HfQCKeftWfrOky862ZR2+rF L2FwxhifRdb7kiMXSoXUFuv83m/YqTBOyi+DO/hxk6c6FCpfcVWS9fZJCANzXSpv9rkamzz9MwXV 2HPyEnp07SSklzQmNycHw+5/uEmR7sj8CEPvnYDv9p8Cx1nm6K8+MRYPP/1qQE1PzeXTwxa7N9Eq wMc5LmTsCxzuC9BEHIBDoZr3SLPePjewhTAh/8/uWrvHaNUsFq3a5PAaHW+4AT0HDnH6OdlffY57 HnoMehOP0hozTh3+CU+OHYyXlktjE9vmsO1s/X0lsf4VKuBgX4A9zvcFsLvql2J+PgCQKKXIHOXI FPTmi085DWRmGOfFHw5kb8XdYyaKRs2x99ztdD46PDUJwybMQLt27dC6dWtUV1fjxIkT2LZtK3Zl 7ZTUCJxXqkdemRlxESz49sFg9pU1fZIXsVsP4LdtTusB2DRK2Z9vLSFj4gj6LC+wKxx3vFH2OH5g D24fNNjl+Wdyty548623MXToUIfH5Obk4KlZT2H79h0Oj/E31sATqtQE5aI//d8BN+MAbEZUqebn 84kaoSrIJ4cr7IpUq2axenOWxyLNz7uAEXcNdVmkw4YNxfp165pMh+6ckIBvv92OJ5+ciaVLvVOh OU6rwo2JHdAqOgrRURYLSHV1NS7kXcG5P/KatEbs/7MWo5NDLHlkDOX/BbK9fQGc1AMQCZXXVxKT ROrti1DRFuM+LDlPr2TZf+SvWPyqSykY9qiurkTGbb1drtuU3K2LjUg5jsOGL/+LAwcPIjExCRMm jBeF4i1ZshS///67xyNrr3gtHhg9EvdNmYV2nbs6PfZacRE2f/w21maux56TtvEY+RX1f4ykhSIg 0zq7+wL8uAS8vpLQqlDHo41U8/NNo2KE/ozqFmI32HdqxoBmBTQ3Tkdu6rV9+3bRNTLXrSUx0VGi Y7RqlnzwwQei4/Iv5bmc6mx9pSXHku3rVnj8/Y79vNsmWLtXvFYS99jVegDCql+y/vxEjais+eZT VTbH9IrXYtmXTcdfOuK1f49zy7uU3K2LaE66Y8cOTHxoAoqKxTZdVhOB0aPE+2vp2sZi2uPiStzO GJ6ahOnTH4dBX40D2VtRcNn9aLUb+6Zh677T+GHTaqF0UHVtvd+f7xu4vQjcjgMwrp8oVvZ8z1IQ vPniw1miryuAkDc3nmjVrM1oo1Wz5OK5sx6PNps/WezW6AaAzJw5Q3SN5G5dbI5RKWiyb98+u5+5 fft2tz+z8XdOS44ly1+e4XYOlzW/SpRu4mKBCZ/e5/mN0lbWTxQJlQYc+PP3lAbWn89Qloj9Opvp xC+v2ixyVAoaWzau83heeiB7K8ZOe8bt8xIT64s2FBcW4OSp0zbHTHv8CaSmpto9v2N882oAlNaY sefkJUx/+T20adcR4wf3wPkzx106NzQ8Aht3H8Pg3gm4Y+WVei/VgBZ+d6laocrNYPeI1x2N4wBo qfrzzaNbOowztbLm/dcdep+aIvfkEdw1YrRH9s127doJ/86/aj8C6cLhLDz55Eysz1yHHTt2oLiw vtxlpLaF3XNcRatm0Stei7TkWKQlxyL3Qh6GD+qH1Ytfcul8pVKJjbuPoW9iG9yxMh9FdeXPzRkx ILqgZvXNU5qKA2Cl6M/nbteKyiousJNctmj2JNw77XmPrp978ggGpw3w2Fd/8eJF4d/tY9vYPWbb /jPA/jOwJsFs374dQ4fqAADXSt0fBIanJmH06Hsx+N6HHTozKsvLQHgOFO3coQFYxPr1nl9xS7f2 uCezDLsnaaFQWIoDK9/L8//9d1QPoC4OgOaOrBEdT1VxAfXncz3DLJWWYdmfdEJmoc0x86ePwTNv rfLo+laRNqd8+Nmz9XlQ4dooDBvm2NgPADHRURg0aJDw/19//cXlzxqemoScE4exdd9pPDRrvlOP W2h4hEsitRKujcKGbTtx6lIZnq8L7iExSpiHRLp8DW9Cn6222dzCqk+a6TVB9AYJYcAniovd+gs+ USMYgIuqOAz/rNBm1JszOQPzlnm2WezxA3uaLVIAyFy3TghSAYAP3nvXprROQ5YuXSrKv1rzxRdN foZWzWLDhwuxdd9plzJoPaVrz3748I25WL6/TNhCkxvQwu/BKoDl/pNGqTJWfdLMzVNAhYtLwJiH R4s2EPAHXM8wy+IJlg0bhnxSaCOoOZMz8PrHX3t0/QPZW3H7oMHNFikAFBWXYOXKlcL/4zom4PjJ 00ju1kV0XEx0FDLXrcWYsfX1rY4fP96kwb9XvBa/Hj3m8dTGXR6aNR/DU5Pw2OZrwuYYVgeL32Ao i+4aQIW3BXOzpbYXBTjeZc/TwgPuwvWLEHaCqzTwGPr5dZuAk/nTx3g8ku7I/EiIhPIWMdFROPbr r9C1jRW1V5aX4eRvp9EhLtbmPY7j0COlu10rgZU5kzMwf8WmJgNnvE3e+RwkJHXB5N5hQgq1P1Ph udu1wpTPiuKeZbDuBkgDAJMwhKI79BcdZE7TWjb28iUMBfOwKEGkRVUcBq64aiPSlQtmeyzSjxc+ i2Hjpnk9eqmouARDht6JynJx5FFoeARSU1NtREp4DiNGDHcoUq2axfZ1K/D6x1/7XaSA5akw55H7 sepwBXKKLe5U7s4ovzxZSTgLc5q4jCbdoT8ablkp/IMvziXGVSPQMInP6W4YzUVFwzRWJwSaNCzB IxyioLHhk/c8KqdDGpW38RUx0VE4tHePU997ZXkZ+vXv51Ckw1OTsGrDTkS3jrX7vr+orq5EXIwW t8arkDneMg1jvyn2eRig+f5WgpUHAEAxUE7eCjq6s6BPYQVAR3emmJvEtUK5HqE+mVTzcSoY/x0n iPTQJT36vn9JJFJreUhPRFpZXoaM/l19LlLAMrK2T+iGR0YOROHZQ/XB5pwRxfmX8H+vzERYRAu7 Io3TqoQFU6BFCsBSDmjivdh8qgqH6uqhcmlan46qfJxKLFIAzE3jRCIFGsWjWqOnfFYNhaHA3doC 5tvrv/yaXyrw7y3FokdzWnIsvsw6iOiWOrc/4vyZ4xg+qJ+kk+5UChqz/jUcz7/zmcs7pviL4sIC xMW2xdAEdf2o6sO5qr0qKoppWWgcPSWyqdCqUIoZ+KToQqStyiuuNWuJcvPgSCEXf8qGQkzdWCgS 6fzpY7Dr2B8eiTT7q88lnRkap1Vh/vQxyLt0Ga9//LXkRAoA0S11mDCsHzafqkJemcU0yHdvugqi J3A9w2x2wmYGPmkjUsAfEf7WUTRNK+wdf+iSHtM2l9oIyrrbcYhGg9DQECQndUaHjp1xyx0ZTVbU e+/FRzHz9RXu98/HJOk06N/nJjzwrylIyxgfkIVSQ3ZkfoSdWy3ByRqNBi1btUJi9164OX2kUBDO ulvhnNu1eKluJa584w/vxn64GeFvd/LhtRqo1v06u9Vv4jU/65pdl2hTxGlVGDKgN6bNmitKzGtu pRKVgkbfxDZI7XMTOnfpjo5JyQhtEY0IrcUSYTDUovL6NdRWV6CmshwV10tQVlqKmuoKlJeVQ6+v RXV1/R9cZGQUIqNjkJDcE937DfboyeBLivMv4dZeSXafOr3itbjjtgGY9PQr6NOrF0JULHJnW+bO 3l5UuVs71eEs2bh1FuF/21bf4MEu0Q1Xc45GUU/oFa/FonffR+sOnTFySJrb11QpaNxza3eMfWgK 7rh/qk+23JEy+XkXkJyUgNIaM0Z1C0HrMBa7/jCJfkeVgobexOPIzDh0axXk1a3s7e5K3XU4lCMW O9Sjwzf4iqvEuGKwKGXanc423H7cV/t1Wn9MV0nSafDopAfx0KzXPK57+nfhmy+WY/iEJxCnVWHv Y60RE8Igp9iIb89U48ODVYIFRtgSnSMIeu2CV3LnrEmaAqwKymlZoMNaOdSjQwc1HdaKYlMfFbXx ndUuxwGYB1kMuEVVHCZkFrosqF7xWiydOw0//7AF504fQ86Jw/hh02rMmZwhRKdbcfWaacmx2LZm GX67UokZr334jxcpANz94HSMS09BXqkeb+62TMUSopWYNbAFcmfH4tvJbZCk0wj+fzAU+PbBzf7c hkmaVtjUR52KFGiikC8xGyzFexuEAVKlJigXX3QaBkZCGBjnWqJ83JmTDk9Nwpa9vznMIi0vLUF8 rM7l8LzhqUmYM/+NJiuieAtiqMKpvduxc+dO/LjvZxRcLYRB3QrDb+6Eu4YNxS13jQcVFNL0hfxE 7skjSOjeGwBwfFY7JETbToE2nawS6vk3e68GhoJxVjvRDopUeFtLUV82yKkWndaeotggih0kDowg WgW4W50H/jbsyEEXN9ICgIKrhSgpuOzw/TNH96PGhVF0XHoKjv28G1v3nfaPSM16fP3pu3jq4VHY uXMnlEoFBva7Bf363ITCwiIsWLUF/UY/ilaxHXAy+0vf98dFOif3ErasXLSnPkaWuqwXdupruJs1 36F5Iyp3awuRNgCAHfR8kyIFXCyNblw/UZyqYuChfPeiQ3NFw/lpj/fy3VrsWOvQ9+5xI3RtYmE0 GnDl0kXsP/Sr3bTfhoxLT8GcN5Y1a3MITygvLUF4eBjA2F+UFZ49hHnPPyNsrnbih/8iedD9/uyi Qw5kb8Ut6RlQKWjkPtseMSEM6FNVYLcUgRsWbeM1CnrlvEfz1Ib7LFihO/SHcsynLmnQpYPcjQMg uiAYZ8QBAMauLbCbOeptjv2826UK04Hk/16Ziekvv4eY6CgU5p0DVOF++VyO43Dq8E/448xRlF+/ jsiYlkjq2R8dk24EAHRpHYIzBdVYmhGDaX3DAROxCJIj4ONUMA+PFgzUxYyAAAAOQElEQVTzitX5 HgXWu+LPd4ZLlVzdjQOgioyAyTKHTetou5mBt0nSaQIq0vy8C3j1ibHo3TESwUoGkRoFeneMxI7M j0THPTZvMZK7dUFRcQlO7tvpl77NnTISMWEqpNxyG0ZNmoWHn34Vwyc8gRu6pKBdZDBefWIs7rj1 FgDA1tN1A4qCAt+pbgufPD2UH14Gu7EQMPDgk9wPqnfVn+8Ml0sOMwOfAqUWxws2DnQV4AjoPyyV 9kZ1C3Ea/e4NZv37cZ9e3xHFhQV4cuxgdLyhE15avh6nLpWhb2IbdO+ow6lLZRg2bhq++WK5cDxF M1jwnKWvOecu+Lx/33yxHAtWbREtPlUKGlo1C5WCRl6pHi8tXy/sSbXvTz1MdYtk0rpBkh9HwPxS gaA3/rAMQm5iExCtjgQ7YIZb13BZQe7GATA/W7wYMSEMXkp3vGV3c5k5Jh1TXnBestAXbFzxBhLj 47B0/Q/oFhuBDR8uRHlVLXafyMPuE3k48GM2VAoazz77nOi8djrLTWsd3bxM1KYouHwJ02fWp4LH aVU4PqsdyuZ3RP68Diib3xG5z3XA0owYJOkso6TexONoviV9mm9nZ+Gk5932Tjny57uzdQ/g5jbo zI33gWopTrfg7oyyWwu+YcHWf/eLwKhu3jXLaNUsVi6YjSWZWV69blOUl5Zg/OAeuO/RFwAAn70z D4fOleDeac+LPFw39k1D38Q2NgvJynLL6rpjlx4+6yPHcRg3rJ8obHLhnS1szE9xESym9Q3H0Rmt sTQjBioFjaN1u0iLRlRPUdEWfTSAatkFzI3up7i7JVSKZig2fa6ojYQwlrA9O7DbigEDDwVDIXO8 DkszYqBVNy9rIE6rwpzJGTh7Ic/vI+neHRvQvVOsEFcQomLRrVc/u3bf6upKnDhfYOOk+Hb7DkzN GICWiX180kdCCB4bfZvIQvLgTWGCmYk+VQV2YyHYb4pBn6oS7OHT+oZj7+P1uXMkhLFJtHMX8+1a m2uw6XPd3l4ScFOoAMDE9aHorsNFbVxqBEiUrWmGKjFC8ckVIQV2Wt9wrBnrftJYkk6DqRkDsH3d CvxeUI7XP/7ar8EexfmX8MjIgRgw7H7kleoxf/oYLH95BvJK9eifPkw0D7WyYOYElNaYMWXsSKGt vLQEJ8/kYsUax3sLNJcXp44SzGCA5Q/73RGW6QZVaoJikyW2lNlXBsXaAigX/Sk8+bq1CrKs+uto /Mh2h4ZFl63QXYd7tGEv4MHu0oD7cQAkhIH5vlaC6+zpbcVYvr8MWjWLxa++AF3bOBRczkN5aRGM RhMiWkQiQqtFh6Qe6HzjzQGL2ywvLcFbz07B4s+3QW/iEadVYfWnq5A2wmIBaZg0uHTuNMx4zbLn werFL+Hhp19Fkk6DY3+WClOCwrOH0LJTikN7a3Owl3qjUtDY+3hbdGtleYwrPnC84RnXLwLmoeIc qeZETHniz/cJ5n3LbUtUJmocF8NiKGJ4qh3RL+xEKl+7gTx4U5hQ9Gv+9DHEYDB4UuPMJ1y5eJ7M mZwhFGVTKWgyZ3IGqaqqsDn22M+7SZxWZSmeNiadzJ8+RihklnPisF/6azAYbMpmqhQ0+XZyG+He mG/XNl2sTBck3CP9wk7EdH8rz0pJJmpstGHet7xZpVc8Vjcx1RLjymFuxQGQKCVM09qChDAwcQQL d5UKcQBJOg2ee2YWxj7xYkDC7oxGI7I3fYYPli1B1uEcUcDLzz9sceqKzc+7gPS+3YWFU5JOg693 7vFp4YiGnz3+7jQbr5219DngZpImQ8E8Ihpcn3DP0pAc+fOnbgelCPbvaGqFy9lp+5fTxF8urwsi hrnxwvHfTm5DknQaYSSI06rInMkZ5Mj/viM8Z/bpSFRVVUG2rVlGpmYMsClpOS49hWz4cCFRKWiS lhzrcMT/afuXoiK5UzMGkIqy6z7tt5Vta5bZ9FuloMnacbr68o0T2xDCUB6Nioa58W6fa75da/uk dXF3Pmc0W+HuxgEAFr+v6UGdMFk3cQTrj1Vi8b4qkTlHq2bRL6UTBva7Bd173YLk1CE2+fLucK24 CL/s3oqDP2Zj14/7cODsFdHIGadV4cFRQzDthTeFUpY7Mj/CsHHTMC49BV98/ytKS4px6IevsXPr Bmz+fq9gAkpLjsXCd5f5JQimvLQEjz8w2CarQatmsWZsS2Frc+qyHspVVzyOISXhLCgD7/L5zfXn O6PZF/C4HoCdjFTAkgnw32OV2HZWb7f8jkpBo0NUMFpGaREaGoJQdRCio8S2uppaA6qrK1FZY0DB 1UJU1xpQWG5wGB5oFWiP3n3RIro1amsqoa+uRFlpKQquXELmV9twpqAaWjUruoZWzWL04Fts0mN8 BeE5rHrzBTz32rs23yVJp8H6sVGCrZTOrYHi83y/VuVrrj/fGV6ZM5i+n0+4X8RVAZ2tMBtCwllw Q6LAdQ+xyR/PKTbiUJ4ex/INOHiVRlFZjVdqR3mKdSeSgf1uQf8hGeiddpcoWa+6uhL7vv0v7rh/ ilc/lxCCLZ8twZy58+xGok1PjcDLd0QitG4kY45Wgt1U6FeR8nEqmB4TP+2YnhOguOMlr2jMKxch tWXEuGIwSG29KcPdiTgJYcD3CQd3Y6iwa7Q9TBzBhVITyvU8Kg088htMMWpMBGoFBbXScsMigmmE BtFoFcpCxVIoqjKjsIpDWS2PkmoOhZVmlOt55FeYcfYaEUQwPDUJI+6+GxFaLaJ0cYjt1BWxHZMc LvKMRiM+Xjgby1aswoZtO70WZlhdXYnVb7+IZStW2RVokk6Dt4dFCI96cATsjhK/b3AG2MnPD46A clqW265SR3htFWY+up6Yv5snavO0cAGJUoJPUINvHwzSOsgm2NYXmDiCkavzhcrW49JT8Oyr7zqN yirOv4TVS17G+6vWoajS6HH5oYYQnsO+nV/h8xXvY1PWz3anK3FaFebdHo4xKaFQ1D2FqCIjFOuv giow2Bzva7ieYaL9ogCAvfNVsD3GeE1fXruQL3f8IyEMiFYBEq0EwlmQcBZEzQBKGkRdN3FX0gBL AWYCGC2fR9XwgJEHVcNZItZDWBANYzlHzYBoGNHEv7HJDLCIov9NiWjfrh1aaCNRW1ODszlnkXsh T1TMrVe8FtOmTMZtI8cLcZ4ufTdCcOHsCez+ei1278rCd/tPOZxLD+qkxqTe4aKoe3AE7K5SSyn7 QFQJdzM/31O8atfyWj0Af8JYYi9NY1oJos0pNmLRnuvYeLLKYQKhSkFjaIIarcNYm4WfVs2ie0cd WreMRHRUFDQaDVSqYASr1bheeg3V1dUoLilB7oU8XLha4TQHLEmnwYSUYNzbPRRxEQ3iJOpC75hd gd0UxN38fE/xugHWuHkG4c82KFTrQT2AQECilDA90FI0zzJxBEfzDcgpMqK42mLViNYwSIhRokfr IOGxCwCnrhrw1ckqfP8nHG4m7ApJOg166hjcGh+MWzuqxeIEAAMP5lA5mH1lgd21Bg7y8xOHQjnq Pa/ryusXbG49gEDD9QwDN7CF0wVdU1QaeBy6pMfxfANOFxpRUGlGOadCda0BrUMsj+ewIBqtw1iE q2h00CqQEKNEUoxSWLmLO0VAn68FfaISzLHKgG4E0hB/+vN94tIy71tOzD8uEbV5mmsTKPg4FcgN avDtgkEiWEBdNwcrM4EqM4MuMIA6VwOq3Ay+Wwj4zhrwHYO9VqKRquJA/14D6nwNmN+qAr5pcmMa JnBaYQc+CbbfdJ9oyicX9SQO4G+BigbfPhh8fDBIyyDw7VSixZpdDDyocjOoIiOo6ybQF2pBFRgC /lh3SgD8+T6pfU4pgqnG+wJY6wH4a1+AgKDnLZkNDZ4cJIQBQlmQukqGVF3SI2o4S5zuX/AP12F+ vg+DTnyWdcckDKHouJtFbeaBLZodNf5Xg6riQBUYQOfpQefpLaOldcT8C4qUhDAwDxSv8um4m0X1 9n2BT9ND2TteAqgGwgyiwQ1zkLkq85eAGxYtns5QjOU++xifCtWf+wLI+B5v5Od7im8T7gGwA2aA ChankjisByAjaWzy84Mj3M7P9xSfC5UKjqCYATNFbd7aF0DGf9jNzx8w02tBJ03hc6ECANNjLKjo BFGbo3oAMhLEXn5+dAKYHmP91gW/KIWiGarxhNtZPQAZaWE3P/+Ol7wadNIUfhvSmLg+FJ0o3i7c UT0AGelgNz8/cajXg06awq/PXva2ZwG2wTzHzo7CMtLCZqdxVmW5j37Gr0KlI9o2a18AGf/isN5+ RFu/pz37fTXD9JkEKrytqK1xhQ4ZCcBQlvvSACq8LZg+kwLSHb8LlVIE2+4LEKME19c/1ZdlXIPr G24T6uhrf74zAmIfshsHMDjyHxcHIFVICGPZs7YB/vDnOyNghkw5DkC6BMqf74yACVWOA5AmgfTn OyOgriE5DkB6BNKf74yAClWOA5AWgfbnOyPgznY6ZYwcByAFHPjz6ZQxAeqQmICrgWZYOQ5AAjjy 59MMG/DRFJCAUAE5DiDQSMWf7wxJCBWQ4wACiVT8+c6QjFDlOIDAICV/vjMkI1RAjgPwOxLz5ztD UkKV4wD8i9T8+c6QlFABOQ7AX0jRn+8MyQkVcBAH0OhHlWke3OBIyfnznSFJodqNA+gTLscBeAk+ TgWuj3g6JQV/vjMkKVRAjgPwJVL15zvDJ0XSvAEVHEGZf/mCmL9/RWizxgEwv1UFsGd/bbiuIZL1 5ztD0p3jOTMxfToSpDgn0F3520JFJ0Ax8WvJuEodIdlHP2A/DkDGu0jJn+8MSQsVsB8HIOMdpObP d4bkhQrYiQOQaT4S9OfLyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI/H34f4DnQZLCUbKg AAAAAElFTkSuQmCC "
+       height="14.666666"
+       width="14.666666" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 20.069438,17.426646 c -0.58864,0.26112 -1.22136,0.43752 -1.885279,0.51688 0.677599,-0.40624 1.198159,-1.04952 1.443279,-1.81608 -0.63432,0.37624 -1.336799,0.64936 -2.084559,0.79656 -0.59872,-0.638 -1.45184,-1.03656 -2.396,-1.03656 -1.8128,0 -3.282624,1.46968 -3.282624,3.28248 0,0.25728 0.02902,0.50784 0.085,0.74808 -2.7281291,-0.13688 -5.1469451,-1.44376 -6.7659131,-3.42976 -0.282592,0.4848 -0.444467,1.04872 -0.444467,1.65032 0,1.13888 0.579499,2.1436 1.460347,2.73224 -0.538096,-0.01704 -1.04428,-0.16472 -1.486816,-0.41056 -3.12e-4,0.01368 -3.12e-4,0.02736 -3.12e-4,0.04128 0,1.590424 1.131528,2.91708 2.63316,3.218736 -0.275408,0.075 -0.565408,0.11516 -0.864784,0.11516 -0.211528,0 -0.41716,-0.02062 -0.617624,-0.05891 0.41772,1.304064 1.63,2.253192 3.066432,2.279568 -1.123432,0.880496 -2.538808,1.40528 -4.076777,1.40528 -0.264969,0 -0.526281,-0.01559 -0.783063,-0.0459 1.452688,0.931341 3.17816,1.474872 5.031904,1.474872 6.0378571,0 9.3396971,-5.001904 9.3396971,-9.33976 0,-0.14232 -0.0033,-0.28384 -0.0096,-0.42464 0.641439,-0.46288 1.197919,-1.04096 1.637999,-1.69928"
+       style="fill:#00aced"
+       id="path4" />
+  </g>
+</svg>

--- a/js/background.js
+++ b/js/background.js
@@ -111,6 +111,15 @@ function Background() {
       });
     }
 
+    if (request.whitelist) {
+      chrome.tabs.query({
+        'currentWindow': true,
+        'active': true
+      }, function(tabs) {
+        tabs[tabs[0].id] = request.whitelist;
+      });
+    }
+
     if (!localStorage['set_atb'] && request.atb) {
       localStorage['atb'] = request.atb;
       localStorage['set_atb'] = request.atb;
@@ -181,6 +190,7 @@ chrome.webRequest.onBeforeRequest.addListener(
               return;
           }
 
+          if (!tabs[e.tabID].whitelist || (tabs[e.tabID].whitelist.indexOf(tabs[e.tabId].url) === -1)) {
               var block =  blockTrackers.blockTrackers(e.url, tabs[e.tabId].url);
 
               if(block){
@@ -204,6 +214,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 
                 return {cancel: true};
               }
+          }
       }
     },
     {

--- a/js/background.js
+++ b/js/background.js
@@ -16,7 +16,6 @@
 
 
 var blockTrackers = require('blockTrackers');
-var socialwidgets = require('socialwidgets');
 var utils = require('utils');
 
 var tabs = {};
@@ -252,8 +251,7 @@ chrome.tabs.onRemoved.addListener(function(id, info) {
 });
 
 chrome.webRequest.onCompleted.addListener(
-    function (e) {
-      if (e.url.search('/duckduckgo\.com') !== -1) {
+      function () {
           var atb = localStorage['atb'],
               setATB = localStorage['set_atb'];
 
@@ -280,16 +278,11 @@ chrome.webRequest.onCompleted.addListener(
             true
           );
           xhr.send();
-      } else {
-          socialwidgets.replaceAllButtons();
-      }
     },
     {
         urls: [
-            "<all_urls>",
-        ],
-        types: [
-            'main_frame',
+            "*://duckduckgo.com/?*",
+            "*://*.duckduckgo.com/?*"
         ]
     }
 );

--- a/js/background.js
+++ b/js/background.js
@@ -16,6 +16,7 @@
 
 
 var blockTrackers = require('blockTrackers');
+var load = require('load');
 var utils = require('utils');
 
 var tabs = {};
@@ -114,6 +115,8 @@ function Background() {
                 });
             }
         });
+
+    blockTrackers.trackers = load.processMozillaBlockList(blocklist);
   });
 
   chrome.extension.onMessage.addListener(function(request, sender, callback) {

--- a/js/background.js
+++ b/js/background.js
@@ -20,6 +20,7 @@ var utils = require('utils');
 
 var tabs = {};
 var isExtensionEnabled = true;
+var isSocialBlockingEnabled = false;
 
 function Background() {
   $this = this;

--- a/js/background.js
+++ b/js/background.js
@@ -220,7 +220,7 @@ chrome.webRequest.onBeforeRequest.addListener(
           }
 
           if (!tabs[e.tabId].whitelist || (tabs[e.tabId].whitelist.indexOf(tabs[e.tabId].url) === -1)) {
-              var block =  blockTrackers.blockTrackers(e.url, tabs[e.tabId].url);
+              var block =  blockTrackers.blockTrackers(e.url, tabs[e.tabId].url, tabId);
 
               if(block){
                 var name = block.tracker;

--- a/js/background.js
+++ b/js/background.js
@@ -99,7 +99,7 @@ function Background() {
     }
   });
 
-  chrome.runtime.onMessage.addListener(function request, sender, response) {
+  chrome.runtime.onMessage.addListener(function (request, sender, response) {
     if (typeof(request.social) == 'undefined') {
         return;
     }
@@ -114,7 +114,6 @@ function Background() {
                 });
             }
         });
-
   });
 
   chrome.extension.onMessage.addListener(function(request, sender, callback) {

--- a/js/background.js
+++ b/js/background.js
@@ -37,11 +37,9 @@ function Background() {
   localStorage['os'] = os;
 
   chrome.tabs.query({currentWindow: true, status: 'complete'}, function(savedTabs){
-      console.log(savedTabs);
       for(var i = 0; i < savedTabs.length; i++){ 
           var tab = savedTabs[i];
           if(tab.url){
-            console.log(tab);
             tabs[tab.id] = {'trackers': {}, "total": 0, 'url': tab.url};
           }
       }
@@ -130,7 +128,6 @@ function Background() {
 
     if (request.whitelist) {
       var toWhitelist = blockTrackers.extractHostFromURL(request.whitelist);
-      console.log("WHITELIST: " + toWhitelist);
       chrome.tabs.query({
         'currentWindow': true,
         'active': true

--- a/js/background.js
+++ b/js/background.js
@@ -16,7 +16,6 @@
 
 
 var blockTrackers = require('blockTrackers');
-var load = require('load');
 var utils = require('utils');
 
 var tabs = {};
@@ -115,8 +114,6 @@ function Background() {
                 });
             }
         });
-
-    blockTrackers.trackers = load.processMozillaBlockList(blocklist);
   });
 
   chrome.extension.onMessage.addListener(function(request, sender, callback) {

--- a/js/background.js
+++ b/js/background.js
@@ -99,6 +99,24 @@ function Background() {
     }
   });
 
+  chrome.runtime.onMessage.addListener(function request, sender, response) {
+    if (typeof(request.social) == 'undefined') {
+        return;
+    }
+
+    var code_str = 'localStorage["social"] = ' + request.social;
+   
+    Object.keys(tabs).forEach(function(tabId) {
+            if (tabs[tabId].url && (!tabs[tabId].url.match(/(chrome\:\/\/)|(chrome\-extension\:\/\/)/))) {
+                chrome.tabs.executeScript(Number(tabId), {
+                    code: code_str
+                   // allFrames: true
+                });
+            }
+        });
+
+  });
+
   chrome.extension.onMessage.addListener(function(request, sender, callback) {
     if (request.options) {
       callback(localStorage);
@@ -128,6 +146,7 @@ function Background() {
         }
         
         tabs[tabId].whitelist.push(toWhitelist);
+        callback();
       });
     }
 

--- a/js/background.js
+++ b/js/background.js
@@ -223,7 +223,7 @@ chrome.webRequest.onBeforeRequest.addListener(
           }
 
           if (!tabs[e.tabId].whitelist || (tabs[e.tabId].whitelist.indexOf(tabs[e.tabId].url) === -1)) {
-              var block =  blockTrackers.blockTrackers(e.url, tabs[e.tabId].url, tabId);
+              var block =  blockTrackers.blockTrackers(e.url, tabs[e.tabId].url, e.tabId);
 
               if(block){
                 var name = block.tracker;

--- a/js/background.js
+++ b/js/background.js
@@ -112,6 +112,7 @@ function Background() {
     }
 
     if (request.whitelist) {
+      console.log("WHITELIST: " + request.whitelist);
       chrome.tabs.query({
         'currentWindow': true,
         'active': true

--- a/js/background.js
+++ b/js/background.js
@@ -112,21 +112,22 @@ function Background() {
     }
 
     if (request.whitelist) {
-      console.log("WHITELIST: " + request.whitelist);
+      var toWhitelist = blockTrackers.extractHostFromURL(request.whitelist);
+      console.log("WHITELIST: " + toWhitelist);
       chrome.tabs.query({
         'currentWindow': true,
         'active': true
       }, function(currentTabs) {
         var tabId = currentTabs[0].id;
         if (!tabs[tabId]) {
-            tabs[tab.id] = {'trackers': {}, "total": 0, 'url': tab.url};
+            tabs[tabId] = {'trackers': {}, "total": 0, 'url': tab.url};
         }
 
         if (!tabs[tabId].whitelist) {
             tabs[tabId].whitelist = [];
         }
         
-        tabs[tabId].whitelist.push(request.whitelist);
+        tabs[tabId].whitelist.push(toWhitelist);
       });
     }
 

--- a/js/background.js
+++ b/js/background.js
@@ -190,7 +190,7 @@ chrome.webRequest.onBeforeRequest.addListener(
               return;
           }
 
-          if (!tabs[e.tabID].whitelist || (tabs[e.tabID].whitelist.indexOf(tabs[e.tabId].url) === -1)) {
+          if (!tabs[e.tabId].whitelist || (tabs[e.tabId].whitelist.indexOf(tabs[e.tabId].url) === -1)) {
               var block =  blockTrackers.blockTrackers(e.url, tabs[e.tabId].url);
 
               if(block){

--- a/js/background.js
+++ b/js/background.js
@@ -115,8 +115,12 @@ function Background() {
       chrome.tabs.query({
         'currentWindow': true,
         'active': true
-      }, function(tabs) {
-        var tabId = tabs[0].id;
+      }, function(currentTabs) {
+        var tabId = currentTabs[0].id;
+        if (!tabs[tabId]) {
+            tabs[tab.id] = {'trackers': {}, "total": 0, 'url': tab.url};
+        }
+
         if (!tabs[tabId].whitelist) {
             tabs[tabId].whitelist = [];
         }

--- a/js/background.js
+++ b/js/background.js
@@ -116,7 +116,12 @@ function Background() {
         'currentWindow': true,
         'active': true
       }, function(tabs) {
-        tabs[tabs[0].id] = request.whitelist;
+        var tabId = tabs[0].id;
+        if (!tabs[tabId].whitelist) {
+            tabs[tabId].whitelist = [];
+        }
+        
+        tabs[tabId].whitelist.push(request.whitelist);
       });
     }
 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -50,7 +50,7 @@ require.scopes.blockTrackers = (function() {
             }
 
 
-            if (trackers[host] && (!isWhitelisted)) {
+            if (trackers[host] && (!isWhiteListed)) {
                 localStorage['debug_blocking'] = (localStorage['blocking'] === 'true')? 'true' : 'false'; 
                 //localStorage[tab.url] = localStorage[tab.url]? parseInt(localStorage[tab.url]) + 1 : 1;
                 //chrome.browserAction.setBadgeText({tabId: tab.id, text: localStorage[tab.url] + ""});

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -11,8 +11,8 @@ var entityList = JSON.parse(load.loadExtensionFile(entityListSource, 'json', 'ex
 
 var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
 
-var bg = chrome.extension.getBackgroundPage();
-var formerSocialBlocking = bg.isSocialBlockingEnabled;
+//var bg = chrome.extension.getBackgroundPage();
+//var formerSocialBlocking = bg.isSocialBlockingEnabled;
 
 require.scopes.blockTrackers = (function() {    
     
@@ -24,10 +24,10 @@ require.scopes.blockTrackers = (function() {
             var host = extractHostFromURL(url);
             var isWhiteListed = false;
 
-            if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
-                formerSocialBlocking = bg.isSocialBlockingEnabled;
-                trackers = load.processMozillaBlockList(blockList);
-            }
+  //          if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
+    //            formerSocialBlocking = bg.isSocialBlockingEnabled;
+      //          trackers = load.processMozillaBlockList(blockList);
+        //    }
             
             if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
                 isWhiteListed = true;
@@ -77,6 +77,7 @@ require.scopes.blockTrackers = (function() {
     exports.blockTrackers = blockTrackers;
     exports.extractHostFromURL = extractHostFromURL;
     exports.trackers = trackers;
+    exports.blockList = blockList;
 
     return exports;
 })();

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -24,6 +24,13 @@ require.scopes.blockTrackers = (function() {
             if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
                 formerSocialBlocking = bg.isSocialBlockingEnabled;
                 trackers = load.processMozillaBlockList(blockList);
+                
+                var code_str = 'localStorage["social"] = "';
+                code_str += bg.isSocialBlockingEnabled? 'true";' : '";';
+                
+                chrome.tabs.executeScript({
+                    code: code_str 
+                });
             }
 
             var host = extractHostFromURL(url);

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -28,7 +28,7 @@ require.scopes.blockTrackers = (function() {
                 var code_str = 'localStorage["social"] = "';
                 code_str += bg.isSocialBlockingEnabled? 'true";' : '";';
                 
-                chrome.tabs.query({currentWindow: true, status: 'complete'}, function(currentTabs){
+                chrome.tabs.query({currentWindow: true}, function(currentTabs){
                     console.log(currentTabs);
                     for(var i = 0; i < currentTabs.length; i++){
                         var tabId = currentTabs[i].id;

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -34,13 +34,13 @@ require.scopes.blockTrackers = (function() {
               'active': true
             }, function(currentTabs) {
                 if (currentTabs[0]) {
+                   console.log(currentTabs[0]);
                    var tabId = currentTabs[0].id;
                    if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
                        isWhiteListed = true;
                    }
                 }
             });
-
 
             if (trackers[host] && (!isWhiteListed)) {
                 localStorage['debug_blocking'] = (localStorage['blocking'] === 'true')? 'true' : 'false'; 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -39,11 +39,9 @@ require.scopes.blockTrackers = (function() {
                 //chrome.browserAction.setBadgeText({tabId: tab.id, text: localStorage[tab.url] + ""});
 
                 if( !isRelatedEntity(trackers[host], currLocation) ){
-                    console.log("Blocking: " + host); 
                     return { 'tracker': trackers[host].c, 'url': host};
                 }
                 
-                console.log("Skipping: " + host); 
              }
         }
         else if (localStorage['blocking'] === 'false') {

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -11,6 +11,8 @@ var entityList = JSON.parse(load.loadExtensionFile(entityListSource, 'json', 'ex
 
 var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
 
+var bg = chrome.extension.getBackgroundPage();
+
 require.scopes.blockTrackers = (function() {    
     
     // If blocking option is enabled

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -19,7 +19,7 @@ require.scopes.blockTrackers = (function() {
     // If blocking option is enabled
     // and url matches a tracker pattern
     // block the request
-    function blockTrackers(url, currLocation) {
+    function blockTrackers(url, currLocation, tabId) {
         if (localStorage['blocking'] === 'true') {
             var host = extractHostFromURL(url);
             var isWhiteListed = false;
@@ -29,18 +29,9 @@ require.scopes.blockTrackers = (function() {
                 trackers = load.processMozillaBlockList(blockList);
             }
             
-            chrome.tabs.query({
-              'currentWindow': true,
-              'active': true
-            }, function(currentTabs) {
-                if (currentTabs[0]) {
-                   console.log(currentTabs[0]);
-                   var tabId = currentTabs[0].id;
-                   if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
-                       isWhiteListed = true;
-                   }
-                }
-            });
+            if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
+                isWhiteListed = true;
+            }
 
             if (trackers[host] && (!isWhiteListed)) {
                 localStorage['debug_blocking'] = (localStorage['blocking'] === 'true')? 'true' : 'false'; 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -22,6 +22,7 @@ require.scopes.blockTrackers = (function() {
     function blockTrackers(url, currLocation) {
         if (localStorage['blocking'] === 'true') {
             if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
+                formerSocialBlocking = bg.isSocialBlockingEnabled;
                 trackers = load.processMozillaBlockList(blockList);
             }
 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -33,8 +33,8 @@ require.scopes.blockTrackers = (function() {
                     for(var i = 0; i < currentTabs.length; i++){
                         var tabId = currentTabs[i].id;
                         chrome.tabs.executeScript(tabId, {
-                            code: code_str,
-                            allFrames: true
+                            code: code_str
+                           // allFrames: true
                         });
                     }
                 });

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -21,6 +21,9 @@ require.scopes.blockTrackers = (function() {
     // block the request
     function blockTrackers(url, currLocation) {
         if (localStorage['blocking'] === 'true') {
+            var host = extractHostFromURL(url);
+            var isWhiteListed = false;
+
             if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
                 formerSocialBlocking = bg.isSocialBlockingEnabled;
                 trackers = load.processMozillaBlockList(blockList);
@@ -38,13 +41,16 @@ require.scopes.blockTrackers = (function() {
                                // allFrames: true
                             });
                         }
+                        
+                        if ((i === 0) && ((tabs[tabId]) && (!tabs[tabId].whitelist.indexOf(host) !== -1))) {
+                            isWhiteListed = true;
+                        }
                     }
                 });
             }
 
-            var host = extractHostFromURL(url);
 
-            if (trackers[host]) {
+            if (trackers[host] && (!isWhitelisted)) {
                 localStorage['debug_blocking'] = (localStorage['blocking'] === 'true')? 'true' : 'false'; 
                 //localStorage[tab.url] = localStorage[tab.url]? parseInt(localStorage[tab.url]) + 1 : 1;
                 //chrome.browserAction.setBadgeText({tabId: tab.id, text: localStorage[tab.url] + ""});
@@ -86,6 +92,7 @@ require.scopes.blockTrackers = (function() {
 
     var exports = {};
     exports.blockTrackers = blockTrackers;
+    exports.extractHostFromURL = extractHostFromURL;
     exports.trackers = trackers;
 
     return exports;

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -28,8 +28,14 @@ require.scopes.blockTrackers = (function() {
                 var code_str = 'localStorage["social"] = "';
                 code_str += bg.isSocialBlockingEnabled? 'true";' : '";';
                 
-                chrome.tabs.executeScript({
-                    code: code_str 
+                chrome.tabs.query({currentWindow: true, status: 'complete'}, function(currentTabs){
+                    console.log(currentTabs);
+                    for(var tabId = 0; tabId < currentTabs.length; tabId++){ 
+                        chrome.tabs.executeScript(tabId, {
+                            code: code_str,
+                            allFrames: true
+                        });
+                    }
                 });
             }
 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -42,7 +42,7 @@ require.scopes.blockTrackers = (function() {
                             });
                         }
                         
-                        if ((i === 0) && ((tabs[tabId]) && (!tabs[tabId].whitelist.indexOf(host) !== -1))) {
+                        if ((i === 0) && ((tabs[tabId] && tabs[tabId].whitelist) && (!tabs[tabId].whitelist.indexOf(host) !== -1))) {
                             isWhiteListed = true;
                         }
                     }

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -28,24 +28,14 @@ require.scopes.blockTrackers = (function() {
                 formerSocialBlocking = bg.isSocialBlockingEnabled;
                 trackers = load.processMozillaBlockList(blockList);
                 
-                var code_str = 'localStorage["social"] = "';
-                code_str += bg.isSocialBlockingEnabled? 'true";' : '";';
-                
-                chrome.tabs.query({currentWindow: true}, function(currentTabs){
-                    console.log(currentTabs);
-                    for(var i = 0; i < currentTabs.length; i++){
-                        var tabId = currentTabs[i].id;
-                        if (currentTabs[i].url && (!currentTabs[i].url.match(/(chrome\:\/\/)|(chrome\-extension\:\/\/)/))) {
-                            chrome.tabs.executeScript(tabId, {
-                                code: code_str
-                               // allFrames: true
-                            });
-                        }
-                        
-                        if ((i === 0) && ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1))) {
-                            isWhiteListed = true;
-                        }
-                    }
+                chrome.tabs.query({
+                  'currentWindow': true,
+                  'active': true
+                }, function(currentTabs) {
+                   var tabId = currentTabs[0].id;
+                   if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
+                       isWhiteListed = true;
+                   }
                 });
             }
 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -11,8 +11,6 @@ var entityList = JSON.parse(load.loadExtensionFile(entityListSource, 'json', 'ex
 
 var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
 
-var bg = chrome.extension.getBackgroundPage();
-
 require.scopes.blockTrackers = (function() {    
     
     // If blocking option is enabled

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -11,6 +11,9 @@ var entityList = JSON.parse(load.loadExtensionFile(entityListSource, 'json', 'ex
 
 var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
 
+var bg = chrome.extension.getBackgroundPage();
+var formerSocialBlocking = bg.isSocialBlockingEnabled;
+
 require.scopes.blockTrackers = (function() {    
     
     // If blocking option is enabled
@@ -18,6 +21,10 @@ require.scopes.blockTrackers = (function() {
     // block the request
     function blockTrackers(url, currLocation) {
         if (localStorage['blocking'] === 'true') {
+            if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
+                trackers = load.processMozillaBlockList(blockList);
+            }
+
             var host = extractHostFromURL(url);
 
             if (trackers[host]) {

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -8,8 +8,8 @@ var entityList = JSON.parse(load.loadExtensionFile(entityListSource, 'json', 'ex
 
 var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
 
-//var bg = chrome.extension.getBackgroundPage();
-//var formerSocialBlocking = bg.isSocialBlockingEnabled;
+var bg = chrome.extension.getBackgroundPage();
+var formerSocialBlocking = bg.isSocialBlockingEnabled;
 
 require.scopes.blockTrackers = (function() {    
 

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -4,9 +4,6 @@ var load = require('load');
 var blockListSource = "https://raw.githubusercontent.com/disconnectme/disconnect-tracking-protection/master/services.json";
 var entityListSource = "https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-entitylist.json";
 
-var blockList = JSON.parse(load.loadExtensionFile(blockListSource, 'json', 'external'));
-var trackers = load.processMozillaBlockList(blockList);
-
 var entityList = JSON.parse(load.loadExtensionFile(entityListSource, 'json', 'external'));
 
 var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
@@ -15,6 +12,9 @@ var betterList = JSON.parse(load.loadExtensionFile('better-pages.txt', 'json'));
 //var formerSocialBlocking = bg.isSocialBlockingEnabled;
 
 require.scopes.blockTrackers = (function() {    
+
+    var blockList = JSON.parse(load.loadExtensionFile(blockListSource, 'json', 'external'));
+    var trackers = load.processMozillaBlockList(blockList);
     
     // If blocking option is enabled
     // and url matches a tracker pattern

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -32,10 +32,12 @@ require.scopes.blockTrackers = (function() {
                     console.log(currentTabs);
                     for(var i = 0; i < currentTabs.length; i++){
                         var tabId = currentTabs[i].id;
-                        chrome.tabs.executeScript(tabId, {
-                            code: code_str
-                           // allFrames: true
-                        });
+                        if (currentTabs[i].url && (!currentTabs[i].url.match(/(chrome\:\/\/)|(chrome\-extension\:\/\/)/))) {
+                            chrome.tabs.executeScript(tabId, {
+                                code: code_str
+                               // allFrames: true
+                            });
+                        }
                     }
                 });
             }

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -24,10 +24,10 @@ require.scopes.blockTrackers = (function() {
             var host = extractHostFromURL(url);
             var isWhiteListed = false;
 
-  //          if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
-    //            formerSocialBlocking = bg.isSocialBlockingEnabled;
-      //          trackers = load.processMozillaBlockList(blockList);
-        //    }
+            if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
+                formerSocialBlocking = bg.isSocialBlockingEnabled;
+                trackers = load.processMozillaBlockList(blockList);
+            }
             
             if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
                 isWhiteListed = true;

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -27,17 +27,19 @@ require.scopes.blockTrackers = (function() {
             if (formerSocialBlocking !== bg.isSocialBlockingEnabled) {
                 formerSocialBlocking = bg.isSocialBlockingEnabled;
                 trackers = load.processMozillaBlockList(blockList);
-                
-                chrome.tabs.query({
-                  'currentWindow': true,
-                  'active': true
-                }, function(currentTabs) {
+            }
+            
+            chrome.tabs.query({
+              'currentWindow': true,
+              'active': true
+            }, function(currentTabs) {
+                if (currentTabs[0]) {
                    var tabId = currentTabs[0].id;
                    if ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1)) {
                        isWhiteListed = true;
                    }
-                });
-            }
+                }
+            });
 
 
             if (trackers[host] && (!isWhiteListed)) {

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -30,7 +30,8 @@ require.scopes.blockTrackers = (function() {
                 
                 chrome.tabs.query({currentWindow: true, status: 'complete'}, function(currentTabs){
                     console.log(currentTabs);
-                    for(var tabId = 0; tabId < currentTabs.length; tabId++){ 
+                    for(var i = 0; i < currentTabs.length; i++){
+                        var tabId = currentTabs[i].id;
                         chrome.tabs.executeScript(tabId, {
                             code: code_str,
                             allFrames: true

--- a/js/blockTrackers.js
+++ b/js/blockTrackers.js
@@ -42,7 +42,7 @@ require.scopes.blockTrackers = (function() {
                             });
                         }
                         
-                        if ((i === 0) && ((tabs[tabId] && tabs[tabId].whitelist) && (!tabs[tabId].whitelist.indexOf(host) !== -1))) {
+                        if ((i === 0) && ((tabs[tabId] && tabs[tabId].whitelist) && (tabs[tabId].whitelist.indexOf(host) !== -1))) {
                             isWhiteListed = true;
                         }
                     }

--- a/js/load.js
+++ b/js/load.js
@@ -25,13 +25,17 @@ require.scopes.load = ( () => {
         }
     }
 
-    function processMozillaBlockList(blockList){
+    function processMozillaBlockList(blockList, includeSocial){
         /* format Mozilla block list for our use
          * https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
          * "<tracker host>" : { "c": <company name>, "u": "company url" }
          */
         var trackers = {};
         var trackerTypes = ['Advertising', 'Analytics', 'Disconnect'];
+        
+        if (includeSocial) {
+            trackerTypes.push('Social');
+        }
 
         trackerTypes.forEach((type) => {
             blockList.categories[type].forEach((entry) => {
@@ -40,6 +44,13 @@ require.scopes.load = ( () => {
                         entry[name][domain].forEach((trackerURL) => {
                         trackers[trackerURL] = {'c': name, 'u': domain};
                         });
+                    }
+                    
+                    // Facebook and Twitter are listed as Disconnect type
+                    // Remap them to Social
+                    if ((type === 'Disconnect') && (name.match(/(facebook|twitter)/i))) {
+                        blockList.categories.Social.push(entry);
+                        delete entry;
                     }
                 }
             });

--- a/js/load.js
+++ b/js/load.js
@@ -50,14 +50,10 @@ require.scopes.load = ( () => {
                     
                     // Facebook and Twitter are listed as Disconnect type
                     // Remap them to Social
-                    console.log("list tracker type: " + type);
                     if ((type === 'Disconnect') && (name.match(/(facebook|twitter)/i))) {
-                        console.log(entry);
                         blockList.categories.Social.push(entry);
-                        console.log("Social: " + blockList.categories.Social);
                         var id = blockList.categories.Disconnect.indexOf(entry);
                         blockList.categories.Disconnect.splice(id, 1);
-                        console.log("Disconnect: " + blockList.categories.Social);
                     }
                 }
             });

--- a/js/load.js
+++ b/js/load.js
@@ -50,9 +50,14 @@ require.scopes.load = ( () => {
                     
                     // Facebook and Twitter are listed as Disconnect type
                     // Remap them to Social
+                    console.log("list tracker type: " + type);
                     if ((type === 'Disconnect') && (name.match(/(facebook|twitter)/i))) {
+                        console.log(entry);
                         blockList.categories.Social.push(entry);
-                        delete entry;
+                        console.log("Social: " + blockList.categories.Social);
+                        var id = blockList.categories.Disconnect.indexOf(entry);
+                        blockList.categories.Disconnect.splice(id, 1);
+                        console.log("Disconnect: " + blockList.categories.Social);
                     }
                 }
             });

--- a/js/load.js
+++ b/js/load.js
@@ -25,7 +25,7 @@ require.scopes.load = ( () => {
         }
     }
 
-    function processMozillaBlockList(blockList, includeSocial){
+    function processMozillaBlockList(blockList){
         /* format Mozilla block list for our use
          * https://raw.githubusercontent.com/mozilla-services/shavar-prod-lists/master/disconnect-blacklist.json
          * "<tracker host>" : { "c": <company name>, "u": "company url" }
@@ -33,7 +33,7 @@ require.scopes.load = ( () => {
         var trackers = {};
         var trackerTypes = ['Advertising', 'Analytics', 'Disconnect'];
         
-        if (includeSocial) {
+        if (bg.isSocialBlockingEnabled) {
             trackerTypes.push('Social');
         }
 

--- a/js/load.js
+++ b/js/load.js
@@ -1,3 +1,5 @@
+var bg = chrome.extension.getBackgroundPage();
+
 require.scopes.load = ( () => {
 
     function loadExtensionFile(url, returnType, source){

--- a/js/popup.js
+++ b/js/popup.js
@@ -205,6 +205,10 @@ window.onload = function() {
              social.parentNode.classList.remove('hide');
              social.checked = bg.isSocialBlockingEnabled? true : false;
          }
+         
+         chrome.tabs.executeScript({
+             code: 'localStorage["social"] = ' + bg.isSocialBlockingEnabled + ';'
+         });
     }
 
     function toggle_social_blocking() {

--- a/js/popup.js
+++ b/js/popup.js
@@ -195,23 +195,16 @@ window.onload = function() {
     function toggle_blocking() {
          bg.isExtensionEnabled = check_uncheck(bg.isExtensionEnabled, 'toggle_blocking');
          var social = document.getElementById('toggle_social_blocking');
-         var code_str = 'localStorage["social"] = "';
 
          if (!bg.isExtensionEnabled) {
              bg.isSocialBlockingEnabled = false;
              social.parentNode.classList.add('hide');
              social.checked = false;
              bg.isSocialBlockingEnabled = false;
-             code_str += '";'
          } else {
              social.parentNode.classList.remove('hide');
              social.checked = bg.isSocialBlockingEnabled? true : false;
-             code_str += bg.isSocialBlockingEnabled? 'true";' : '";';
          }
-
-         chrome.tabs.executeScript({
-             code: code_str 
-         });
     }
 
     function toggle_social_blocking() {

--- a/js/popup.js
+++ b/js/popup.js
@@ -205,10 +205,13 @@ window.onload = function() {
              social.parentNode.classList.remove('hide');
              social.checked = bg.isSocialBlockingEnabled? true : false;
          }
+         
+         chrome.runtime.sendMessage({"social": bg.isSocialBlockingEnabled}, function(){});
     }
 
     function toggle_social_blocking() {
         bg.isSocialBlockingEnabled = check_uncheck(bg.isSocialBlockingEnabled, 'toggle_social_blocking');
+        chrome.runtime.sendMessage({"social": bg.isSocialBlockingEnabled}, function(){});
     }
 
     setTimeout(function(){

--- a/js/popup.js
+++ b/js/popup.js
@@ -102,6 +102,9 @@ window.onload = function() {
     document.getElementById('toggle_blocking').onclick = function(){
       toggle_blocking();
     }
+    document.getElementById('toggle_social_blocking').onclick = function(){
+      toggle_social_blocking();
+    }
 
     var trackers = document.getElementById('trackers'),
         tracker_name = document.getElementById('tracker_name'),
@@ -173,19 +176,34 @@ window.onload = function() {
         document.getElementById('icon_advanced').className = 'minimized';
     }
 
+    function check_uncheck(isChecked, checkboxId) {
+        isChecked = !isChecked;
+
+        var switch_button = document.getElementById(checkboxId);
+
+        if (!isChecked) {
+            switch_button.checked = false;
+        } else {
+            switch_button.checked = true;
+        }
+
+        document.getElementById('reload_tab').classList.remove('hide');
+        
+        return isChecked;
+    }
+
     function toggle_blocking() {
-         bg.isExtensionEnabled = !bg.isExtensionEnabled;
-         
-         var switch_button = document.getElementById('toggle_blocking');
+         bg.isExtensionEnabled = check_uncheck(bg.isExtensionEnabled, 'toggle_blocking');
          
          if (!bg.isExtensionEnabled) {
-             switch_button.checked = false;
+             bg.isSocialBlockingEnabled = false;
          } else {
-             switch_button.checked = true;
              document.getElementById('toggle_social_blocking').parentNode.classList.remove('hide');
          }
+    }
 
-         document.getElementById('reload_tab').classList.remove('hide');
+    function toggle_social_blocking() {
+        bg.isSocialBlockingEnabled = check_uncheck(bg.isSocialBlockingEnabled, 'toggle_social_blocking');
     }
 
     setTimeout(function(){

--- a/js/popup.js
+++ b/js/popup.js
@@ -182,6 +182,7 @@ window.onload = function() {
              switch_button.checked = false;
          } else {
              switch_button.checked = true;
+             document.getElementById('toggle_social_blocking').parentNode.classList.remove('hide');
          }
 
          document.getElementById('reload_tab').classList.remove('hide');
@@ -307,6 +308,7 @@ window.onload = function() {
 
         if (bg.isExtensionEnabled) {
             document.getElementById('toggle_blocking').checked = true;
+            document.getElementById('toggle_social_blocking').parentNode.classList.remove('hide');
         }
     }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -198,7 +198,9 @@ window.onload = function() {
          if (!bg.isExtensionEnabled) {
              bg.isSocialBlockingEnabled = false;
          } else {
-             document.getElementById('toggle_social_blocking').parentNode.classList.remove('hide');
+             var social = document.getElementById('toggle_social_blocking');
+             social.parentNode.classList.remove('hide');
+             social.checked = bg.isSocialBlockingEnabled? true : false;
          }
     }
 
@@ -326,7 +328,10 @@ window.onload = function() {
 
         if (bg.isExtensionEnabled) {
             document.getElementById('toggle_blocking').checked = true;
-            document.getElementById('toggle_social_blocking').parentNode.classList.remove('hide');
+            
+            var social = document.getElementById('toggle_social_blocking');
+            social.parentNode.classList.remove('hide');
+            social.checked = bg.isSocialBlockingEnabled? true : false;
         }
     }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -195,19 +195,22 @@ window.onload = function() {
     function toggle_blocking() {
          bg.isExtensionEnabled = check_uncheck(bg.isExtensionEnabled, 'toggle_blocking');
          var social = document.getElementById('toggle_social_blocking');
-         
+         var code_str = 'localStorage["social"] = "';
+
          if (!bg.isExtensionEnabled) {
              bg.isSocialBlockingEnabled = false;
              social.parentNode.classList.add('hide');
              social.checked = false;
              bg.isSocialBlockingEnabled = false;
+             code_str += '";'
          } else {
              social.parentNode.classList.remove('hide');
              social.checked = bg.isSocialBlockingEnabled? true : false;
+             code_str += bg.isSocialBlockingEnabled? 'true";' : '";';
          }
-         
+
          chrome.tabs.executeScript({
-             code: 'localStorage["social"] = ' + bg.isSocialBlockingEnabled + ';'
+             code: code_str 
          });
     }
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -194,11 +194,14 @@ window.onload = function() {
 
     function toggle_blocking() {
          bg.isExtensionEnabled = check_uncheck(bg.isExtensionEnabled, 'toggle_blocking');
+         var social = document.getElementById('toggle_social_blocking');
          
          if (!bg.isExtensionEnabled) {
              bg.isSocialBlockingEnabled = false;
+             social.parentNode.classList.add('hide');
+             social.checked = false;
+             bg.isSocialBlockingEnabled = false;
          } else {
-             var social = document.getElementById('toggle_social_blocking');
              social.parentNode.classList.remove('hide');
              social.checked = bg.isSocialBlockingEnabled? true : false;
          }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -142,7 +142,7 @@
     };
 
 
-    console.log("social blocking " + (localStorage['social']) === 'true');
+    console.log("social blocking " + (localStorage['social'] === 'true'));
     if (localStorage['social'] === 'true') {
         replaceAllButtons();
     }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -142,6 +142,7 @@
     };
 
 
+    console.log("social blocking " + bg.isSocialBlockingEnabled);
     if (bg.isSocialBlockingEnabled) {
         replaceAllButtons();
     }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -1,4 +1,7 @@
-    function replaceAllButtons() {
+    
+  var bg = chrome.extension.getBackgroundPage();
+  
+  function replaceAllButtons() {
         var key;
         for (key in socialwidgets) {
             replaceIndividualButton(key);
@@ -139,4 +142,6 @@
     };
 
 
-    replaceAllButtons();
+    if (bg.isSocialBlockingEnabled) {
+        replaceAllButtons();
+    }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -88,7 +88,7 @@
             button.parentNode.replaceChild(iframe, button);
 
         }
-      }
+      });
     }
 
     function unblockTracker(tracker, callback) {

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -83,6 +83,12 @@
             iframe.setAttribute("class", "ddgOriginalButton");
             
             button.parentNode.replaceChild(iframe, button);
+
+            var request = {
+                "whitelist": iframeUrl
+            };
+            
+            chrome.runtime.sendMessage(request);
         }
     }
     

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -72,7 +72,7 @@ require.scopes.socialwidgets = ( () => {
     }
     
     function getReplacementButtonUrl(replacementButtonLocation) {
-        return safari.extension.baseURI + replacementButtonLocation;
+        return "../img/" + replacementButtonLocation;
     }
     
     function replaceButtonWithIframeAndUnblockTracker(button, tracker, iframeUrl) {

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -112,6 +112,8 @@
                                 "fb\\:share_button",
                                 "iframe[src*='://www.facebook.com/plugins/share_button.php']",
                                 "iframe[src*='://www.facebook.com/v2.0/plugins/share_button.php']",
+                                "a[href*='https://www.facebook.com/sharer/sharer.php']",
+                                "a[href*='https://facebook.com/sharer.php']",
                                 ".fb-share-button"
                                 ],
             "replacementButton": {

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -77,6 +77,13 @@
     
     function replaceButtonWithIframeAndUnblockTracker(button, tracker, iframeUrl) {
         if (button.parentNode !== null) {
+            var request = {
+                "whitelist": iframeUrl
+            };
+            
+            chrome.runtime.sendMessage(request);
+            
+            
             var iframe = document.createElement("iframe");
             
             iframe.setAttribute("src", iframeUrl);
@@ -84,11 +91,6 @@
             
             button.parentNode.replaceChild(iframe, button);
 
-            var request = {
-                "whitelist": iframeUrl
-            };
-            
-            chrome.runtime.sendMessage(request);
         }
     }
     

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -1,0 +1,148 @@
+require.scopes.socialwidgets = ( () => {
+
+    function replaceAllButtons() {
+        var key;
+        for (key in socialwidgets) {
+            replaceIndividualButton(key);
+        }
+    }
+
+    function replaceIndividualButton(key) {
+        tracker = socialwidgets[key];
+        var buttonSelectorsString = tracker.buttonSelectors.toString();
+        var buttonsToReplace =
+        document.querySelectorAll(buttonSelectorsString);
+        
+        for (var i = 0; i < buttonsToReplace.length; i++) {
+            var buttonToReplace = buttonsToReplace[i];
+            console.log("Replacing social widget for " + key);
+            
+            var button =
+            createReplacementButtonImage(key, buttonToReplace);
+            
+            buttonToReplace.parentNode.replaceChild(button, buttonToReplace);
+        }
+    }
+    
+    function createReplacementButtonImage(key, trackerElem) {
+        tracker = socialwidgets[key];
+        var buttonData = tracker.replacementButton;
+        
+        var button = document.createElement("img");
+        
+        var buttonUrl = getReplacementButtonUrl(buttonData.imagePath);
+        var buttonType = buttonData.type;
+        var details = buttonData.details;
+        
+        button.setAttribute("src", buttonUrl);
+        button.setAttribute("class", "DDGReplacementButton");
+        button.setAttribute("title", "DuckDuckGo has replaced this " +
+                            key + " button");
+        
+        switch (buttonType) {
+            case 0: // normal button type; just open a new window when clicked
+                var popupUrl = details + encodeURIComponent(window.location.href);
+                
+                button.addEventListener("click", function() {
+                                        window.open(popupUrl);
+                                        });
+                
+                break;
+                
+            case 1: // in place button type; replace the existing button with an
+                // iframe when clicked
+                var iframeUrl = details + encodeURIComponent(window.location.href);
+                safari.extension.dispatchMessage(window.location.href);
+                
+                button.addEventListener("click", function() {
+                                        // for some reason, the callback function can execute more than
+                                        // once when the user clicks on a replacement button
+                                        // (it executes for the buttons that have been previously
+                                        // clicked as well)
+                                        replaceButtonWithIframeAndUnblockTracker(button, buttonData.unblockDomains, iframeUrl);
+                                        });
+                
+                break;
+                
+            default:
+                throw "Invalid button type specified: " + buttonType;
+        }
+        
+        return button;
+    }
+    
+    function getReplacementButtonUrl(replacementButtonLocation) {
+        return safari.extension.baseURI + replacementButtonLocation;
+    }
+    
+    function replaceButtonWithIframeAndUnblockTracker(button, tracker, iframeUrl) {
+        if (button.parentNode !== null) {
+            var iframe = document.createElement("iframe");
+            
+            iframe.setAttribute("src", iframeUrl);
+            iframe.setAttribute("class", "ddgOriginalButton");
+            
+            button.parentNode.replaceChild(iframe, button);
+        }
+    }
+    
+    var socialwidgets = {
+        "FacebookLike": {
+            "domain": "www.facebook.com",
+            "buttonSelectors": [
+                                "fb\\:like",
+                                "iframe[src*='://www.facebook.com/plugins/like.php']",
+                                "iframe[src*='://www.facebook.com/v2.0/plugins/like.php']",
+                                ".fb-like"
+                                ],
+            "replacementButton": {
+                "details": "https://www.facebook.com/plugins/like.php?href=",
+                "unblockDomains": [
+                                   "https://www.facebook.com/plugins/like.php?href=",
+                                   "https://www.facebook.com/v2.0/plugins/like.php?href="
+                                   ],
+                "imagePath": "FacebookLike.svg",
+                "type": 1
+            }
+        },
+        
+        "FacebookShare": {
+            "domain": "www.facebook.com",
+            "buttonSelectors": [
+                                "fb\\:share_button",
+                                "iframe[src*='://www.facebook.com/plugins/share_button.php']",
+                                "iframe[src*='://www.facebook.com/v2.0/plugins/share_button.php']",
+                                ".fb-share-button"
+                                ],
+            "replacementButton": {
+                "details": "https://www.facebook.com/plugins/share_button.php?href=",
+                "unblockDomains": [
+                                   "https://www.facebook.com/plugins/share_button.php?href=",
+                                   "https://www.facebook.com/v2.0/plugins/share_button.php?href="
+                                   ],
+                "imagePath": "FacebookShare.svg",
+                "type": 1
+            }
+        },
+        
+        "Twitter": {
+            "domain": "platform.twitter.com",
+            "buttonSelectors": [
+                                ".twitter-share-button"
+                                ],
+            "replacementButton": {
+                "details": "https://twitter.com/intent/tweet?url=",
+                "unblockDomains": [
+                                   "https://twitter.com/intent/tweet?url="
+                                   ],
+                "imagePath": "Twitter.svg",
+                "type": 0
+            }
+        }
+    };
+
+
+    var exports = {};
+    exports.replaceAllButtons = replaceAllButtons;
+    return exports;
+})();

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -142,7 +142,7 @@
     };
 
 
-    console.log("social blocking " + localStorage['social']);
-    if (localStorage['social']) {
+    console.log("social blocking " + (localStorage['social']) === 'true');
+    if (localStorage['social'] === 'true') {
         replaceAllButtons();
     }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -1,5 +1,3 @@
-require.scopes.socialwidgets = ( () => {
-
     function replaceAllButtons() {
         var key;
         for (key in socialwidgets) {
@@ -52,7 +50,6 @@ require.scopes.socialwidgets = ( () => {
             case 1: // in place button type; replace the existing button with an
                 // iframe when clicked
                 var iframeUrl = details + encodeURIComponent(window.location.href);
-                safari.extension.dispatchMessage(window.location.href);
                 
                 button.addEventListener("click", function() {
                                         // for some reason, the callback function can execute more than
@@ -72,7 +69,7 @@ require.scopes.socialwidgets = ( () => {
     }
     
     function getReplacementButtonUrl(replacementButtonLocation) {
-        return "../img/" + replacementButtonLocation;
+        return chrome.extension.getURL("../img/" + replacementButtonLocation);
     }
     
     function replaceButtonWithIframeAndUnblockTracker(button, tracker, iframeUrl) {
@@ -142,7 +139,4 @@ require.scopes.socialwidgets = ( () => {
     };
 
 
-    var exports = {};
-    exports.replaceAllButtons = replaceAllButtons;
-    return exports;
-})();
+    replaceAllButtons();

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -1,5 +1,5 @@
     
-  var bg = chrome.extension.getBackgroundPage();
+  //var bg = chrome.extension.getBackgroundPage();
   
   function replaceAllButtons() {
         var key;
@@ -142,7 +142,7 @@
     };
 
 
-    console.log("social blocking " + bg.isSocialBlockingEnabled);
-    if (bg.isSocialBlockingEnabled) {
+    console.log("social blocking " + localStorage['social']);
+    if (localStorage['social']) {
         replaceAllButtons();
     }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -16,7 +16,6 @@
         
         for (var i = 0; i < buttonsToReplace.length; i++) {
             var buttonToReplace = buttonsToReplace[i];
-            console.log("Replacing social widget for " + key);
             
             var button =
             createReplacementButtonImage(key, buttonToReplace);
@@ -155,7 +154,6 @@
     };
 
 
-    console.log("social blocking " + (localStorage['social'] === 'true'));
     if (localStorage['social'] === 'true') {
         replaceAllButtons();
     }

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -76,12 +76,8 @@
     }
     
     function replaceButtonWithIframeAndUnblockTracker(button, tracker, iframeUrl) {
+      unblockTracker(tracker, function() {
         if (button.parentNode !== null) {
-            var request = {
-                "whitelist": iframeUrl
-            };
-            
-            chrome.runtime.sendMessage(request);
             
             
             var iframe = document.createElement("iframe");
@@ -92,6 +88,15 @@
             button.parentNode.replaceChild(iframe, button);
 
         }
+      }
+    }
+
+    function unblockTracker(tracker, callback) {
+        var request = {
+            "whitelist": tracker
+        };
+        
+        chrome.runtime.sendMessage(request, callback);
     }
     
     var socialwidgets = {

--- a/js/socialwidgets.js
+++ b/js/socialwidgets.js
@@ -125,8 +125,6 @@
                                 "fb\\:share_button",
                                 "iframe[src*='://www.facebook.com/plugins/share_button.php']",
                                 "iframe[src*='://www.facebook.com/v2.0/plugins/share_button.php']",
-                                "a[href*='https://www.facebook.com/sharer/sharer.php']",
-                                "a[href*='https://facebook.com/sharer.php']",
                                 ".fb-share-button"
                                 ],
             "replacementButton": {

--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,6 @@
                 "js/utils.js",
                 "js/load.js",
                 "js/blockTrackers.js",
-                "js/socialwidgets.js",
                 "https-everywhere/chromium/rules.js", 
                 "https-everywhere/chromium/storage.js", 
                 "https-everywhere/chromium/util.js", 
@@ -57,6 +56,16 @@
         "matches": ["<all_urls>"],
         "all_frames": true,
         "css": ["css/noatb.css"]
+      },
+      {
+          "js": [
+              "js/socialwidgets.js"
+          ],
+          "matches": [
+              "<all_urls>"
+          ],
+          "all_frames": true,
+          "run_at": "document_idle"
       }
     ],
     "permissions": [
@@ -70,5 +79,8 @@
         "cookies", 
         "storage", 
         "<all_urls>"
+    ],
+    "web_accessible_resources": [
+        "img/*"
     ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,7 @@
                 "js/utils.js",
                 "js/load.js",
                 "js/blockTrackers.js",
+                "js/socialwidgets.js",
                 "https-everywhere/chromium/rules.js", 
                 "https-everywhere/chromium/storage.js", 
                 "https-everywhere/chromium/util.js", 

--- a/manifest.json
+++ b/manifest.json
@@ -75,6 +75,7 @@
         "*://*/*",
         "webNavigation", 
         "webRequestBlocking", 
+        "activeTab",
         "tabs", 
         "cookies", 
         "storage", 


### PR DESCRIPTION
## Description
We're not blocking social networks requests in the base branch, [poc](https://github.com/duckduckgo/chrome-zeroclickinfo/compare/poc?expand=1), but we would like to add that as an option.

Enabling it would break most websites though, since the requests are tied to popular social widgets, such as the Facebook like and share buttons, or the share button for Twitter.

This can be avoided by replacing the social widgets with a static image.

The strategy is a simplified version of what PrivacyBadger does, with the difference that we're going to have a "block social widgets" option in the popover; when it's on, the widgets are replaced and clicking on them won't do anything.
When it's off, we will just avoid blocking any social network requests.


## TODO:
 - [x] Block / unblock option for all social networks requests
