### PR TITLE
check for complete status

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -240,9 +240,13 @@ chrome.tabs.onReplaced.addListener(function (addedTabId) {
 });
 
 chrome.tabs.onUpdated.addListener(function(id, info, tab) {
-    if(tabs[id] && info.status === "loading"){
-        tabs[id] = {'trackers': {}, "total": 0, 'url': tab.url};
+    if(tabs[id] && info.status === "loading" && tabs[id].status !== "loading"){
+        tabs[id] = {'trackers': {}, "total": 0, 'url': tab.url, "status": "loading"};
     }
+    else if(tabs[id] && info.status === "complete"){
+        tabs[id].status = "complete";
+    }
+
 });
 
 chrome.tabs.onRemoved.addListener(function(id, info) {


### PR DESCRIPTION
When loading some sites we get multiple onUpdated events with a "loading" status. This changes the event listener so that we are keeping track of the tab status and only clear the tracker list if the tab has finished loading.