### PR TITLE
add option for replacing embedded tweets with no-tracking tweet content

### DIFF
--- a/data/default_settings.json
+++ b/data/default_settings.json
@@ -3,6 +3,7 @@
     "socialBlockingIsEnabled": false,
     "trackerBlockingEnabled": true,
     "httpsEverywhereEnabled": true,
+    "embeddedTweetsEnabled": false,
     "meanings": true,
     "advanced_options": true,
     "last_search": "",

--- a/js/models/privacy-options.es6.js
+++ b/js/models/privacy-options.es6.js
@@ -5,6 +5,7 @@ function PrivacyOptions (attrs) {
 
     attrs.trackerBlockingEnabled = backgroundPage.settings.getSetting('trackerBlockingEnabled');
     attrs.httpsEverywhereEnabled = backgroundPage.settings.getSetting('httpsEverywhereEnabled');
+    attrs.embeddedTweetsEnabled = backgroundPage.settings.getSetting('embeddedTweetsEnabled');
 
     Parent.call(this, attrs);
 

--- a/js/templates/privacy-options.es6.js
+++ b/js/templates/privacy-options.es6.js
@@ -17,6 +17,12 @@ module.exports = function () {
                                'js-options-https-everywhere-enabled',
                                'httpsEverywhereEnabled')}
             </li>
+            <li>
+                Show Embedded Tweets
+                ${toggleButton(this.model.embeddedTweetsEnabled,
+                               'js-options-embedded-tweets-enabled',
+                               'embeddedTweetsEnabled')}
+            </li>
         </ul>
     </section>`;
 }

--- a/js/trackers.js
+++ b/js/trackers.js
@@ -14,6 +14,17 @@ function isTracker(url, currLocation, tabId) {
 
     var toBlock = false;
 
+    // DEMO embedded tweet option
+    // a more robust test for tweet code may need to be used besides just
+    // blocking platform.twitter.com
+    if (settings.getSetting('embeddedTweetsEnabled') === false) {
+        if (/platform.twitter.com/.test(url)) {
+            console.log("blocking tweet embedded code on " + url);
+            return {parentCompany: "twitter", url: "platform.twitter.com", type: "Analytics"};
+        }
+    }
+
+
     if (settings.getSetting('trackerBlockingEnabled')) {
         
         var host = utils.extractHostFromURL(url);

--- a/js/views/privacy-options.es6.js
+++ b/js/views/privacy-options.es6.js
@@ -26,11 +26,12 @@ PrivacyOptions.prototype = $.extend({},
 
         setup: function() {
 
-            this._cacheElems('.js-options', [ 'blocktrackers', 'https-everywhere-enabled' ]);
+            this._cacheElems('.js-options', [ 'blocktrackers', 'https-everywhere-enabled', 'embedded-tweets-enabled']);
 
             this.bindEvents([
               [this.$blocktrackers, 'click', this._clickSetting],
-              [this.$httpseverywhereenabled, 'click', this._clickSetting]
+              [this.$httpseverywhereenabled, 'click', this._clickSetting],
+              [this.$embeddedtweetsenabled, 'click', this._clickSetting]
             ]);
 
         },


### PR DESCRIPTION
Adds option to block requests to twitter widget code, which will show the text of a tweet without the embedded tweet widget. May need some tweaking, blocking platform.twitter.com might be too blunt. Or maybe embedded tweets should be ON by default.

This is effectively what Firefox does in private browsing windows.


- Add embedded tweet option, off by default
- blocks requests to platform.twitter.com when this is OFF

<img width="455" alt="screen shot 2017-06-02 at 9 45 44 am" src="https://cloud.githubusercontent.com/assets/333669/26728959/f72a7c8a-4779-11e7-90f2-36e4ac928077.png">


#### embedded tweets ON:

<img width="524" alt="screen shot 2017-06-02 at 9 50 50 am" src="https://cloud.githubusercontent.com/assets/333669/26728707/1f72ead4-4779-11e7-8b1c-7e655290fe7a.png">

#### embedded tweets OFF:

<img width="563" alt="screen shot 2017-06-02 at 9 51 20 am" src="https://cloud.githubusercontent.com/assets/333669/26728720/2acd598c-4779-11e7-95a2-6db120b142ce.png">

#### Sites style their unadorned tweets differently:

<img width="742" alt="screen shot 2017-06-02 at 9 48 51 am" src="https://cloud.githubusercontent.com/assets/333669/26728854/9a27ca10-4779-11e7-9749-bd92db7ef1fd.png">

<img width="733" alt="screen shot 2017-06-02 at 9 49 35 am" src="https://cloud.githubusercontent.com/assets/333669/26728860/a29f93a8-4779-11e7-91a4-897200625c27.png">


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
