### PR TITLE
firefox popup url

### DIFF
--- a/js/models/site.es6.js
+++ b/js/models/site.es6.js
@@ -38,7 +38,11 @@ Site.prototype = $.extend({},
 
       setSiteObj: function() {
           if (!this.tab) {
-              this.domain = '-';    // should not happen
+              // firefox new tab page doesn't fire an onUpdated event so we don't have a tab yet
+              if (backgroundPage.browser === "moz")
+                  this.domain = "new tab";
+              else
+                this.domain = '-';    // should not happen
           }
           else {
               this.isWhitelisted = this.tab.site.whiteListed;

--- a/js/site.js
+++ b/js/site.js
@@ -77,6 +77,16 @@ class Site{
         if (this.domain === 'newtab')
             return "new tab";
 
+        if (browser === "moz") {
+            if (!this.domain) {
+                return "add-ons";
+            }
+            // look for firefox uuid as a domain on some addon: pages
+            if (this.domain.match(/^[a-z0-9]{8}(-[a-z0-9]{4}){3}-[a-z0-9]{12}$/)){
+                return  "add-ons"
+            }
+        }
+
         return false;
     }
 }

--- a/js/site.js
+++ b/js/site.js
@@ -78,12 +78,13 @@ class Site{
             return "new tab";
 
         if (browser === "moz") {
+            // special case for saved/reopend about: firefox tabs
             if (!this.domain) {
-                return "add-ons";
+                return "about";
             }
             // look for firefox uuid as a domain on some addon: pages
             if (this.domain.match(/^[a-z0-9]{8}(-[a-z0-9]{4}){3}-[a-z0-9]{12}$/)){
-                return  "add-ons"
+                return  "about"
             }
         }
 

--- a/js/site.js
+++ b/js/site.js
@@ -77,15 +77,9 @@ class Site{
         if (this.domain === 'newtab')
             return "new tab";
 
-        if (browser === "moz") {
-            // special case for saved/reopend about: firefox tabs
-            if (!this.domain) {
-                return "about";
-            }
-            // look for firefox uuid as a domain on some addon: pages
-            if (this.domain.match(/^[a-z0-9]{8}(-[a-z0-9]{4}){3}-[a-z0-9]{12}$/)){
-                return  "about"
-            }
+        // special case for about: firefox tabs
+        if (browser === "moz" && !this.domain) {
+            return "about";
         }
 
         return false;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,9 @@
 require.scopes.utils = ( () => {
 
     function extractHostFromURL(url) {
+        if (!url)
+            return;
+
         var a = parseURL(url)
         var parts = a.hostname.split('.');
         // remove subdomains from url

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
       }
     },
     "omnibox": {"keyword": "d"},
-    "options_page": "html/options.html",
+    "options_ui": {"page": "html/options.html"},
     "background": {
             "scripts": [
                 "https/chromium/rules.js",

--- a/manifest.json
+++ b/manifest.json
@@ -85,7 +85,6 @@
         "webRequestBlocking",
         "*://*/*",
         "webNavigation",
-        "webRequestBlocking",
         "activeTab",
         "tabs",
         "cookies",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

Fixes the popup site URL in Firefox. There were a few differences in Firefox that I'm handling:
- The `tabs.onUpdated` doesn't fire on new tab creation in Firefox like it does in Chrome.
- Since the tab event doesn't fire we may not have a site object url. This is only a problem for about and new tab pages.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
