### PR TITLE
ignore last error when messaging popup

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -124,7 +124,6 @@ chrome.webRequest.onBeforeRequest.addListener(
               return;
           }
 
-
           // update badge here to display a 0 count
           updateBadge(thisTab.id, thisTab.getBadgeTotal());
           chrome.runtime.sendMessage({"rerenderPopup": true}, ignoreLastError);

--- a/js/background.js
+++ b/js/background.js
@@ -124,9 +124,10 @@ chrome.webRequest.onBeforeRequest.addListener(
               return;
           }
 
+
           // update badge here to display a 0 count
           updateBadge(thisTab.id, thisTab.getBadgeTotal());
-          chrome.runtime.sendMessage({"rerenderPopup": true});
+          chrome.runtime.sendMessage({"rerenderPopup": true}, ignoreLastError);
       
           var tracker =  trackers.isTracker(requestData.url, thisTab.url, thisTab.id, requestData);
       
@@ -142,7 +143,7 @@ chrome.webRequest.onBeforeRequest.addListener(
               if (!thisTab.site.whiteListed) {
                   thisTab.addOrUpdateTracker(tracker);
                   updateBadge(thisTab.id, thisTab.getBadgeTotal());
-                  chrome.runtime.sendMessage({"rerenderPopup": true});
+                  chrome.runtime.sendMessage({"rerenderPopup": true}, ignoreLastError);
 
                   console.info( utils.extractHostFromURL(thisTab.url)
                                + " [" + tracker.parentCompany + "] " + tracker.url);
@@ -196,3 +197,10 @@ chrome.webRequest.onCompleted.addListener(
         ]
     }
 );
+
+function ignoreLastError() {
+    if (chrome.runtime.lastError) {
+        // do nothing
+    }
+}
+


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

Sending a message to the popup when it doesn't exist (isn't open) causes an error in the developer console.
`Unchecked lastError value: Error: Could not establish connection. Receiving end does not exist.`

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 