### PR TITLE
noatb css at document start

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -67,7 +67,8 @@
       {
         "matches": ["<all_urls>"],
         "all_frames": true,
-        "css": ["public/css/noatb.css"]
+        "css": ["public/css/noatb.css"],
+        "run_at": "document_start"
       },
       {
           "js": [


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

The ATB modal briefly appears before the noatb css is injected. We can inject the css earlier by setting "run_at: document_start".

Works on both firefox and chrome so I made this PR to the beta branch.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

1. install extension in firefox
2. go to duckduckgo.com
3. you shouldn't see the ATB modal

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
