### PR TITLE
set score to 'none' on special page

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -9,7 +9,8 @@
 const siteScores = ['A', 'B', 'C', 'D']
 
 class Score {
-    constructor() {
+    constructor(specialPage) {
+        this.specialPage = specialPage;
         this.hasHTTPS = false;
         this.inMajorTrackingNetwork = false;
         this.totalBlocked = 0;
@@ -21,6 +22,8 @@ class Score {
      */
     get() {
         let scoreIndex = 1;
+
+        if (this.specialPage) return 'none';
 
         if (this.inMajorTrackingNetwork) scoreIndex++
         if (this.hasHTTPS) scoreIndex--
@@ -66,7 +69,7 @@ class Site{
     constructor(domain) {
         this.domain = domain,
         this.trackers = [],
-        this.score = new Score();
+        this.score = new Score(this.specialDomain());
 
         // whitelist only HTTPS upgrades
         this.HTTPSwhitelisted = false;

--- a/js/site.js
+++ b/js/site.js
@@ -10,7 +10,7 @@ const siteScores = ['A', 'B', 'C', 'D']
 
 class Score {
     constructor(specialPage) {
-        this.specialPage = specialPage;
+        this.specialPage = specialPage;     // see specialDomain() in class Site below
         this.hasHTTPS = false;
         this.inMajorTrackingNetwork = false;
         this.totalBlocked = 0;
@@ -21,9 +21,9 @@ class Score {
      * Calculates and returns a site score
      */
     get() {
-        let scoreIndex = 1;
-
         if (this.specialPage) return 'none';
+
+        let scoreIndex = 1;
 
         if (this.inMajorTrackingNetwork) scoreIndex++
         if (this.hasHTTPS) scoreIndex--

--- a/js/tabManager.js
+++ b/js/tabManager.js
@@ -65,6 +65,8 @@ chrome.tabs.onUpdated.addListener( (id, info) => {
                     chrome.tabs.reload(tab.id);
                 }
 
+                console.info(tab.site.score);
+
                 tab.updateBadgeIcon();
             }
         }


### PR DESCRIPTION
Set score to 'none' so there is no score icon on the special domains for new tab, extensions, etc.
Does this by sending the domain through the score constructor to set the property `specialPage` when a new Site object is instantiated, and using this to short-circuit the score calculation in score `get()`

This means a new property of the score class will be the value of specialPage, eg 'new tab' or `false` for better context when interpreting a score object.

I chose to implement this as a special case rather than extend the score array (eg make index zero be 'none', index one be 'A', ..)  because that is precisely what a special page is – it's not on a sliding scale with the rest of the properties of a normal page.

Also added console logging of the score when the page load is complete (at the point where the toolbar icon is updated).

<img width="304" alt="screen shot 2017-06-23 at 12 54 37 am" src="https://user-images.githubusercontent.com/333669/27467228-a68ddebc-57ae-11e7-8726-95e64289a928.png">


###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
