### PR TITLE
migrate atb

### DIFF
--- a/js/atb.js
+++ b/js/atb.js
@@ -60,6 +60,20 @@ var ATB = (() => {
             }
         },
 
+        // migrate old versions that used localstorage over to 
+        // use setting and chrome.storage.local
+        migrate: () => {
+            let atbNames = ['atb', 'set_atb']
+            atbNames.map((name) => {
+                let val = localStorage[name]
+                if (val) {
+                    console.log("Migrate ATB: ", name + " " +val);
+                    settings.updateSetting(name, val)
+                    localStorage[name] = ''
+                }
+            });
+        },
+
         setInitialVersions: () => {
             if(!settings.getSetting('atb')){
                 let versions = ATB.calculateInitialVersions();
@@ -118,6 +132,10 @@ var ATB = (() => {
         },
 
         onInstalled: () => {
+            // we already migrate on update events but just to be
+            // safe lets do this on install too
+            ATB.migrate();
+
             ATB.setInitialVersions();
             ATB.inject();
             

--- a/js/atb.js
+++ b/js/atb.js
@@ -60,16 +60,14 @@ var ATB = (() => {
             }
         },
 
-        // migrate old versions that used localstorage over to 
-        // use setting and chrome.storage.local
+        // migrate old versions that used localstorage over to use settings and chrome.storage.local
         migrate: () => {
             let atbNames = ['atb', 'set_atb']
             atbNames.map((name) => {
-                let val = localStorage[name]
-                if (val) {
-                    console.log("Migrate ATB: ", name + " " +val);
-                    settings.updateSetting(name, val)
-                    localStorage[name] = ''
+                let localValue = localStorage[name]
+                let storageValue = settings.getSetting(name)
+                if (localValue && !storageValue) {
+                    settings.updateSetting(name, localValue)
                 }
             });
         },

--- a/js/background.js
+++ b/js/background.js
@@ -67,6 +67,9 @@ function Background() {
         ATB.onInstalled();
         ATB.startUpPage();
     }
+    else if (details.reason === "upgrade") {
+        ATB.migrate()
+    }
   });
 }
 

--- a/test/tests/atb.js
+++ b/test/tests/atb.js
@@ -1,9 +1,24 @@
 (function() {
  
   QUnit.module("ATB");
-  
+  var bkg = chrome.extension.getBackgroundPage();
+
+  QUnit.test("Test ATB migration", function (assert) {
+      // make some fake atb values in localStorage
+      bkg.localStorage['atb'] = 'old-atb-value';
+      bkg.localStorage['set_atb'] = 'old-set-atb-value';
+
+      ATB.migrate();
+
+      assert.ok(settings.getSetting('atb') === "old-atb-value", "ATB value should be migrated to setting");
+      assert.ok(settings.getSetting('set_atb') === "old-set-atb-value", "set ATB value should be migrated to setting");
+
+      assert.ok(localStorage['atb'] === '', "localstorage should be cleared");
+      assert.ok(localStorage['set_atb'] === '', "localstorage should be cleared");
+  });
+
   QUnit.test("Testing ATB module", function (assert) {
-      
+
       // test appending atb value to only ddg urls
       var urlTests = [
       { 'url': 'http://duckduckgo.com/?q=something', 'rewrite': true },

--- a/test/tests/atb.js
+++ b/test/tests/atb.js
@@ -2,8 +2,12 @@
  
   QUnit.module("ATB");
   var bkg = chrome.extension.getBackgroundPage();
-
   QUnit.test("Test ATB migration", function (assert) {
+      
+      // clear any existing atb before we start the tests
+      settings.updateSetting('atb', '');
+      settings.updateSetting('set_atb', '');
+
       // make some fake atb values in localStorage
       bkg.localStorage['atb'] = 'old-atb-value';
       bkg.localStorage['set_atb'] = 'old-set-atb-value';
@@ -13,8 +17,15 @@
       assert.ok(settings.getSetting('atb') === "old-atb-value", "ATB value should be migrated to setting");
       assert.ok(settings.getSetting('set_atb') === "old-set-atb-value", "set ATB value should be migrated to setting");
 
-      assert.ok(localStorage['atb'] === '', "localstorage should be cleared");
-      assert.ok(localStorage['set_atb'] === '', "localstorage should be cleared");
+      // Try to migrate again. This shouldn't overwrite the now existing storage ATB values
+      bkg.localStorage['atb'] = 'some-other-value';
+      bkg.localStorage['set_atb'] = 'some-other-set-atb-value';
+
+      ATB.migrate();
+
+      assert.ok(settings.getSetting('atb') === "old-atb-value", "migrate should not overwrite existing ATB");
+      assert.ok(settings.getSetting('set_atb') === "old-set-atb-value", "migrate should not overwrite existing ATB");
+
   });
 
   QUnit.test("Testing ATB module", function (assert) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->

The current extension stores ATB values in localStorage. For the new version we are instead using chrome.storage.local. I added a migrate method to copy the localStorage atb values over to our settings which will be automatically synced to chrome.storage.local.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
