### PR TITLE
Disable "see all" link for page-level trackers on new tab(s)

### DIFF
--- a/css/trackers.scss
+++ b/css/trackers.scss
@@ -229,6 +229,14 @@ body {
                 padding-top: 4.5px;
                 padding-bottom: 3.5px;
                 display: block;
+
+                body.disabled & {
+                    cursor: default;
+
+                    &:hover {
+                        text-decoration: none;
+                    }
+                }
             }
         }
     }

--- a/js/templates/trackerlist-tabbed.es6.js
+++ b/js/templates/trackerlist-tabbed.es6.js
@@ -19,7 +19,6 @@ module.exports = function () {
         </section>`;
 
     } else if (this.model.companyListMap) {
-
         if (this.model.companyListMap.length > 0) {
             return bel`<ol class="menu-list top-blocked__list card js-top-blocked-list">
                 ${trackerListItems(this.model.companyListMap)}

--- a/js/views/site.es6.js
+++ b/js/views/site.es6.js
@@ -11,6 +11,8 @@ function Site (ops) {
 
     Parent.call(this, ops);
 
+    this.$body = $('body');
+
     // bind events
     this._setup();
 
@@ -83,10 +85,11 @@ Site.prototype = $.extend({},
         },
 
         _setDisabled: function() {
-            $('body').addClass('disabled');
+            this.$body.addClass('disabled');
         },
 
         _showAllTrackers: function () {
+            if (this.$body.hasClass('disabled')) return;
             this.views.slidingSubview = new TrackerListSlidingSubview({
                 template: tabbedTrackerListTemplate,
                 defaultTab: 'page'


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
@russellholt 
<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
When the extension is in a "disabled" state (as in the case of a new empty tab), disable ability to click on page-level see all link, remove active link indicators via css (change to default cursor, no underlining of link).
https://app.asana.com/0/0/376323084765025

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
