### PR TITLE
Reload page when site is whitelisted via popup toggle

### DIFF
--- a/js/ui/models/site.es6.js
+++ b/js/ui/models/site.es6.js
@@ -27,21 +27,6 @@ Site.prototype = $.extend({},
 
       modelName: 'site',
 
-      toggleWhitelist: function () {
-          if (this.tab.site) {
-              this.isWhitelisted = !this.isWhitelisted;
-              
-              backgroundPage.tabManager.whitelistDomain({
-                  list: 'whitelisted',
-                  domain: this.tab.site.domain, 
-                  value: this.isWhitelisted
-              });
-
-              this.tab.site.notifyWhitelistChanged();
-              this.setWhitelistStatusText();
-          }
-      },
-
       setSiteObj: function() {
           if (!this.tab) {
               this.domain = 'new tab'; // tab can be null for firefox new tabs
@@ -60,22 +45,8 @@ Site.prototype = $.extend({},
           }
       },
 
-      updateTrackerCount: function() {
-          if (this.tab) {
-            this.trackersCount = this.tab.getUniqueTrackersCount();
-            this.trackersBlockedCount = this.tab.getUniqueTrackersBlockedCount();
-            this.updateSiteScore();
-          }
-      },
-
-      updateSiteScore: function() {
-          this.siteRating = this.tab.site.score.get()
-      },
-
-      setHttpsMessage: function() {
-          if (!this.tab) {
-              return;
-          }
+      setHttpsMessage: function () {
+          if (!this.tab) return
 
           if (this.tab.upgradedHttps) {
               this.httpsState = 'upgraded';
@@ -93,7 +64,46 @@ Site.prototype = $.extend({},
           } else {
               this.whitelistStatusText = whitelistStates['notWhitelisted'];
           }
+      },
+
+      update: function () {
+          let rerenderFlag = false;
+
+          if (this.tab) {
+            const updatedTrackersCount = this.tab.getUniqueTrackersCount()
+            const updatedTrackersBlockedCount = this.tab.getUniqueTrackersBlockedCount()
+            const updatedSiteRating = this.tab.site.score.get()
+
+            if (updatedTrackersCount !== this.trackersCount) {
+              this.trackersCount = updatedTrackersCount
+              rerenderFlag = true
+            }
+            if (updatedTrackersBlockedCount !== this.trackersBlockedCount) {
+              this.trackersBlockedCount = updatedTrackersBlockedCount
+              rerenderFlag = true
+            }
+            if (updatedSiteRating !== this.siteRating) {
+              this.siteRating = updatedSiteRating
+            }
+          }
+
+          return rerenderFlag
+      },
+
+      toggleWhitelist: function () {
+          if (this.tab && this.tab.site) {
+              this.isWhitelisted = !this.isWhitelisted;
+              backgroundPage.tabManager.whitelistDomain({
+                  list: 'whitelisted',
+                  domain: this.tab.site.domain,
+                  value: this.isWhitelisted
+              });
+
+              this.tab.site.notifyWhitelistChanged();
+              this.setWhitelistStatusText();
+          }
       }
+
   }
 );
 

--- a/js/ui/models/site.es6.js
+++ b/js/ui/models/site.es6.js
@@ -75,16 +75,16 @@ Site.prototype = $.extend({},
               const updatedSiteRating = this.tab.site.score.get()
 
               if (updatedTrackersCount !== this.trackersCount) {
-                this.trackersCount = updatedTrackersCount
-                rerenderFlag = true
+                  this.trackersCount = updatedTrackersCount
+                  rerenderFlag = true
               }
               if (updatedTrackersBlockedCount !== this.trackersBlockedCount) {
-                this.trackersBlockedCount = updatedTrackersBlockedCount
-                rerenderFlag = true
+                  this.trackersBlockedCount = updatedTrackersBlockedCount
+                  rerenderFlag = true
               }
               if (updatedSiteRating !== this.siteRating) {
-                this.siteRating = updatedSiteRating
-                rerenderFlag = true
+                  this.siteRating = updatedSiteRating
+                  rerenderFlag = true
               }
           }
 

--- a/js/ui/models/site.es6.js
+++ b/js/ui/models/site.es6.js
@@ -71,7 +71,13 @@ Site.prototype = $.extend({},
 
           if (this.tab) {
             const updatedTrackersCount = this.tab.getUniqueTrackersCount()
+            console.log('this.trackersCount: ' + this.trackersCount)
+            console.log('updatedTrackersCount: ' + updatedTrackersCount)
+
             const updatedTrackersBlockedCount = this.tab.getUniqueTrackersBlockedCount()
+            console.log('this.trackersBlockedCount: ' + this.trackersBlockedCount)
+            console.log('updatedTrackersBlockedCount: ' + updatedTrackersBlockedCount)
+
             const updatedSiteRating = this.tab.site.score.get()
 
             if (updatedTrackersCount !== this.trackersCount) {
@@ -86,7 +92,7 @@ Site.prototype = $.extend({},
               this.siteRating = updatedSiteRating
             }
           }
-
+          if (rerenderFlag) console.log('>>>>> rerenderFlag: ' + rerenderFlag)
           return rerenderFlag
       },
 
@@ -98,7 +104,6 @@ Site.prototype = $.extend({},
                   domain: this.tab.site.domain,
                   value: this.isWhitelisted
               });
-
               this.tab.site.notifyWhitelistChanged();
               this.setWhitelistStatusText();
           }

--- a/js/ui/models/site.es6.js
+++ b/js/ui/models/site.es6.js
@@ -67,32 +67,27 @@ Site.prototype = $.extend({},
       },
 
       update: function () {
-          let rerenderFlag = false;
+          let rerenderFlag = false
 
           if (this.tab) {
-            const updatedTrackersCount = this.tab.getUniqueTrackersCount()
-            console.log('this.trackersCount: ' + this.trackersCount)
-            console.log('updatedTrackersCount: ' + updatedTrackersCount)
+              const updatedTrackersCount = this.tab.getUniqueTrackersCount()
+              const updatedTrackersBlockedCount = this.tab.getUniqueTrackersBlockedCount()
+              const updatedSiteRating = this.tab.site.score.get()
 
-            const updatedTrackersBlockedCount = this.tab.getUniqueTrackersBlockedCount()
-            console.log('this.trackersBlockedCount: ' + this.trackersBlockedCount)
-            console.log('updatedTrackersBlockedCount: ' + updatedTrackersBlockedCount)
-
-            const updatedSiteRating = this.tab.site.score.get()
-
-            if (updatedTrackersCount !== this.trackersCount) {
-              this.trackersCount = updatedTrackersCount
-              rerenderFlag = true
-            }
-            if (updatedTrackersBlockedCount !== this.trackersBlockedCount) {
-              this.trackersBlockedCount = updatedTrackersBlockedCount
-              rerenderFlag = true
-            }
-            if (updatedSiteRating !== this.siteRating) {
-              this.siteRating = updatedSiteRating
-            }
+              if (updatedTrackersCount !== this.trackersCount) {
+                this.trackersCount = updatedTrackersCount
+                rerenderFlag = true
+              }
+              if (updatedTrackersBlockedCount !== this.trackersBlockedCount) {
+                this.trackersBlockedCount = updatedTrackersBlockedCount
+                rerenderFlag = true
+              }
+              if (updatedSiteRating !== this.siteRating) {
+                this.siteRating = updatedSiteRating
+                rerenderFlag = true
+              }
           }
-          if (rerenderFlag) console.log('>>>>> rerenderFlag: ' + rerenderFlag)
+
           return rerenderFlag
       },
 

--- a/js/ui/views/site.es6.js
+++ b/js/ui/views/site.es6.js
@@ -30,7 +30,7 @@ function Site (ops) {
                 thisView._setDisabled();
             }
 
-            thisModel.updateTrackerCount();
+            thisModel.update();
             thisModel.setHttpsMessage();
             thisView.rerender(); // our custom rerender below
 
@@ -48,8 +48,7 @@ function Site (ops) {
 
     chrome.runtime.onMessage.addListener(function(req, sender, res) {
         if (req.updateTrackerCount) {
-            thisModel.updateTrackerCount();
-            thisView.rerender(); // our custom rerender below
+            if (thisModel.update()) thisView.rerender();
         }
     });
 
@@ -70,7 +69,6 @@ Site.prototype = $.extend({},
               [this.$toggle, 'click', this._whitelistClick],
               [this.$showalltrackers, 'click', this._showAllTrackers]
             ]);
-
 
         },
 

--- a/js/ui/views/site.es6.js
+++ b/js/ui/views/site.es6.js
@@ -82,18 +82,9 @@ Site.prototype = $.extend({},
             this.model.toggleWhitelist();
             console.log('isWhitelisted: ', this.model.isWhitelisted);
 
-
             chrome.tabs.reload(this.model.tab.id);
-            // BUG: trackersBlocked doesn't seem to be updating
-            // when going from blocking OFF to ON
-            // it stays at 0
-            // same when going from blocking ON to OFF
-            // but when you completely close and reopen popup,
-            // the counts are correct
-            this.getBackgroundTabData();
-
-
-            this.rerender();
+            const w = chrome.extension.getViews({type: 'popup'})[0];
+            w.close()
         },
 
         rerender: function() {

--- a/js/ui/views/site.es6.js
+++ b/js/ui/views/site.es6.js
@@ -28,9 +28,7 @@ function Site (ops) {
 
     let self = this;
     chrome.runtime.onMessage.addListener(function(req, sender, res) {
-        console.log('!!!! listener on msg:', req)
         if (req.updateTrackerCount) {
-            console.log('call update() with conditional rerender')
             if (self.model.update()) thisView.rerender();
         }
     });


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
@jdorweiler 
<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Reload page when site is whitelisted via popup toggle (works in both FF and Chrome)
https://app.asana.com/0/318512979878271/377696002991234/f

This PR also fixes another ongoing problem by refactoring the site info rendering in the popup. Before, it was re-rendering the site info view on every heartbeat from background. Now, it only re-renders when the counts for both/either `trackers`, `trackersBlocked` have changed or site score has changed. 
https://app.asana.com/0/312010458275645/384484491544972/f

## Steps to test this PR:
1. pull down branch and `grunt build`
2. visit a web page, open extension and click "blocking on/off" toggle
3. watch page reload, popup close
4. observe correct blocking on/off behavior with correct counts

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
