### PR TITLE
Firefox: handle private mode messaging

### DIFF
--- a/css/trackers.scss
+++ b/css/trackers.scss
@@ -22,6 +22,21 @@ body {
 
 #trackers-container {
 
+    .failover.card {
+        position: absolute;
+        top: 14px;
+        right:  7px;
+        bottom: 63px;
+        left: 7px;
+
+        p {
+            padding: 7px 21px;
+            font-weight: bold;
+            font-size: 15px;
+            color: $platinum-darker;
+        }
+    }
+
     .search-form {
 
         .search-form__input {

--- a/js/ui/models/privacy-options.es6.js
+++ b/js/ui/models/privacy-options.es6.js
@@ -6,9 +6,7 @@ function PrivacyOptions (attrs) {
     attrs.trackerBlockingEnabled = backgroundPage.settings.getSetting('trackerBlockingEnabled');
     attrs.httpsEverywhereEnabled = backgroundPage.settings.getSetting('httpsEverywhereEnabled');
     attrs.embeddedTweetsEnabled = backgroundPage.settings.getSetting('embeddedTweetsEnabled');
-
     Parent.call(this, attrs);
-
 };
 
 

--- a/js/ui/templates/failover.es6.js
+++ b/js/ui/templates/failover.es6.js
@@ -1,0 +1,7 @@
+const bel = require('bel');
+
+module.exports = function () {
+    return bel`<section class="failover card">
+      <p>${this.message}</p>
+    </section>`;
+}

--- a/js/ui/views/failover.es6.js
+++ b/js/ui/views/failover.es6.js
@@ -1,0 +1,16 @@
+const Parent = window.DDG.base.View;
+
+function Failover (ops) {
+    this.template = ops.template;
+    this.message = ops.message;
+    Parent.call(this, ops);
+};
+
+Failover.prototype = $.extend({},
+    Parent.prototype,
+    {
+
+    }
+);
+
+module.exports = Failover;


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
@jdorweiler 

**CC:**

## Description:
https://app.asana.com/0/318512979878271/393875706390692/f

This at least lets the user know that in Firefox private browsing mode, we can't communicate with background page directly instead of rendering a blank popup. In the future, we might want to consider other options (or not). Consider this a band-aid if that's the case.

@jdorweiler Take a look, but maybe hold off on the merge until we hear from Russell that this is indeed how we want to handle this.

![screen shot 2017-07-26 at 4 55 17 pm](https://user-images.githubusercontent.com/1278969/28648778-0d636fea-7225-11e7-953a-f3af60f4795d.png)

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
