### PR TITLE
only add atb to duckduckgo.com

### DIFF
--- a/js/atb.js
+++ b/js/atb.js
@@ -1,5 +1,5 @@
 var ATB = (() => {
-    var ddgRegex = 'https:\/\/duckduckgo\.com/\?.*';
+    var ddgRegex = 'https://(\W\.)?duckduckgo\.com/\?.*'
     var ddgAtbURL = 'https://duckduckgo.com/atb.js?';
 
     return {

--- a/js/atb.js
+++ b/js/atb.js
@@ -1,5 +1,5 @@
 var ATB = (() => {
-    var ddgRegex = '/duckduckgo\.com';
+    var ddgRegex = 'https:\/\/duckduckgo\.com/\?.*';
     var ddgAtbURL = 'https://duckduckgo.com/atb.js?';
 
     return {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
Updated the regex to only add atb params to duckduckgo.com. This matches what is used in the old extension https://github.com/duckduckgo/firefox-zeroclickinfo/blob/master/lib/ddg-atb.js#L25

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
