### PR TITLE
Migrate to options page v2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,10 @@
       }
     },
     "omnibox": {"keyword": "d"},
-    "options_page": "html/options.html",
+    "options_ui": {
+        "page": "html/options.html",
+        "chrome_style": true
+    },
     "background": {
             "scripts": [
                 "data/defaultSettings.js",


### PR DESCRIPTION
More informations about the UI on https://developer.chrome.com/extensions/optionsV2

**Reviewer:**

## Description:

`options_ui` is available since `chrome@40` and gives a nicer modal layout to the options page.


## Steps to test this PR:

- install extension in Developer Mode
- open the extension Options via a right click on its icon or via the Manage Extensions menu
- witness it opens in a modal rather than in a new tab

## Automated tests:

N/A (or having a JSON linter for the `manifest.json` file)

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [x] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [x] Consider systems implications 
