### PR TITLE
tab status code and don't count trackers on redirects

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -165,10 +165,10 @@ chrome.webRequest.onBeforeRequest.addListener(
                 // blocked below but not counted toward company stats
                 if (thisTab.statusCode === 200) {
                     // record all tracker urls on a site even if we don't block them
-                    thisTab.site.addTracker(tracker);
+                    thisTab.site.addTracker(tracker)
 
                     // record potential blocked trackers for this tab
-                    thisTab.addToTrackers(tracker);
+                    thisTab.addToTrackers(tracker)
                 }
 
                 // Block the request if the site is not whitelisted

--- a/js/companies.js
+++ b/js/companies.js
@@ -16,6 +16,8 @@ var Companies = ( () => {
     return {
         get: (name) => { return companyContainer[name] },
 
+        getTotalPages: () => { return totalPages },
+
         add: (name) => {
             if(!companyContainer[name]){
                 companyContainer[name] = new Company(name);
@@ -57,6 +59,7 @@ var Companies = ( () => {
 
         clearData: () => { 
             companyContainer = {};
+            totalPages = 0
             topBlocked.clear();
         },
 

--- a/js/tab.js
+++ b/js/tab.js
@@ -55,6 +55,7 @@ class Tab {
         this.requestId = tabData.requestId
         this.status = tabData.status
         this.site = new Site(utils.extractHostFromURL(tabData.url))
+        this.statusCode // statusCode is set when headers are recieved in tabManager.js
 
         // set the new tab icon to the dax logo
         chrome.browserAction.setIcon({path: 'img/icon_48.png', tabId: tabData.tabId})

--- a/js/tabManager.js
+++ b/js/tabManager.js
@@ -129,9 +129,9 @@ chrome.webRequest.onHeadersReceived.addListener( (request) => {
         tab.statusCode = request.statusCode
 
         if (tab.statusCode === 200) {
-            tab.url = request.url;
-            tab.updateSite();
-            Companies.incrementPages();
+            tab.url = request.url
+            tab.updateSite()
+            Companies.incrementPages()
         }
     }
 }, {urls: ['<all_urls>'], types: ['main_frame']});

--- a/js/tabManager.js
+++ b/js/tabManager.js
@@ -123,11 +123,16 @@ chrome.runtime.onMessage.addListener( (req, sender, res) => {
 // update tab url after the request is finished. This makes
 // sure we have the correct url after any https rewrites
 chrome.webRequest.onHeadersReceived.addListener( (request) => {
+    
     let tab = tabManager.get({tabId: request.tabId});
     if (tab) {
-        tab.url = request.url;
-        tab.updateSite();
-        Companies.incrementPages();
+        tab.statusCode = request.statusCode
+
+        if (tab.statusCode === 200) {
+            tab.url = request.url;
+            tab.updateSite();
+            Companies.incrementPages();
+        }
     }
 }, {urls: ['<all_urls>'], types: ['main_frame']});
 


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
<!-- Explain what is being changed, why, etc -->
- added the status code to the tab. This is set when we receive the headers. 
- only increment the total page count with 200 status codes
- only record trackers that are on tabs with a 200 http status code
- still block trackers on a tab regardless of http status code

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->
Run the unit tests. I included a unit test to verify the total number of pages and that we have correct company percent data. 

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
