### PR TITLE
replace surveymonkey links with mailto

### DIFF
--- a/js/ui/models/hamburger-menu.es6.js
+++ b/js/ui/models/hamburger-menu.es6.js
@@ -2,7 +2,7 @@ const Parent = window.DDG.base.Model
 
 function HamburgerMenu (attrs) {
     attrs = attrs || {}
-    attrs.domain = ''
+    attrs.tabUrl = ''
     Parent.call(this, attrs)
 }
 

--- a/js/ui/models/hamburger-menu.es6.js
+++ b/js/ui/models/hamburger-menu.es6.js
@@ -2,6 +2,7 @@ const Parent = window.DDG.base.Model
 
 function HamburgerMenu (attrs) {
     attrs = attrs || {}
+    attrs.domain = ''
     Parent.call(this, attrs)
 }
 

--- a/js/ui/models/site.es6.js
+++ b/js/ui/models/site.es6.js
@@ -40,7 +40,7 @@ Site.prototype = $.extend({},
                   if (tab) {
                       this.fetch({getTab: tab.id}).then((backgroundTabObj) => {
                           if (backgroundTabObj) {
-                              this.tab = backgroundTabObj
+                              this.set('tab', backgroundTabObj)
                               this.domain = backgroundTabObj.site.domain
                               this.fetchSiteRating()
                               this.tosdr = backgroundTabObj.site.score.tosdr

--- a/js/ui/templates/hamburger-menu.es6.js
+++ b/js/ui/templates/hamburger-menu.es6.js
@@ -19,14 +19,14 @@ module.exports = function () {
                     </a>
                 </li>
                 <li>
-                    <a href="mailto:firefox@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F"
+                    <a href="mailto:extension-feedback@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F"
                         class="menu-title">
                         Send feedback
                         <span>Got issues or suggestions? Let us know!</span>
                     </a>
                 </li>
                 <li>
-                    <a href="mailto:firefox@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%29%0A"
+                    <a href="mailto:extension-brokensites@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%29%0A"
                         class="menu-title">
                         Report broken site
                         <span>If a site's not working, please tell us.</span>

--- a/js/ui/templates/hamburger-menu.es6.js
+++ b/js/ui/templates/hamburger-menu.es6.js
@@ -18,14 +18,14 @@ module.exports = function () {
                     </a>
                 </li>
                 <li>
-                    <a href="${renderFeedbackHref(this.model.domain)}"
+                    <a href="${renderFeedbackHref(this.model.tabUrl)}"
                         class="menu-title">
                         Send feedback
                         <span>Got issues or suggestions? Let us know!</span>
                     </a>
                 </li>
                 <li>
-                    <a href="${renderBrokenSiteHref(this.model.domain)}"
+                    <a href="${renderBrokenSiteHref(this.model.tabUrl)}"
                         class="menu-title">
                         Report broken site
                         <span>If a site's not working, please tell us.</span>
@@ -36,10 +36,10 @@ module.exports = function () {
     </nav>`
 }
 
-function renderFeedbackHref (domain) {
-    return `mailto:extension-feedback@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F%20%20%2E%0A%0AURL%20is%20${domain}`
+function renderFeedbackHref (url) {
+    return `mailto:extension-feedback@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F%20%20%2E%0A%0A----URL%20is%20${encodeURIComponent(url)}`
 }
 
-function renderBrokenSiteHref (domain) {
-    return `mailto:extension-brokensites@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%29%0AURL%20is%20${domain}`
+function renderBrokenSiteHref (url) {
+    return `mailto:extension-brokensites@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%0A%0A----URL%20is%20${encodeURIComponent(url)}`
 }

--- a/js/ui/templates/hamburger-menu.es6.js
+++ b/js/ui/templates/hamburger-menu.es6.js
@@ -19,17 +19,15 @@ module.exports = function () {
                     </a>
                 </li>
                 <li>
-                    <a href="https://www.surveymonkey.com/r/feedback_firefox"
-                        class="menu-title"
-                        target="_blank">
+                    <a href="mailto:firefox@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you've%20encountered.%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F"
+                        class="menu-title">
                         Send feedback
                         <span>Got issues or suggestions? Let us know!</span>
                     </a>
                 </li>
                 <li>
-                    <a href="https://www.surveymonkey.com/r/V6L5ZY2"
-                        class="menu-title"
-                        target="_blank">
+                    <a href="mailto:firefox@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%29%0A"
+                        class="menu-title">
                         Report broken site
                         <span>If a site's not working, please tell us.</span>
                     </a>

--- a/js/ui/templates/hamburger-menu.es6.js
+++ b/js/ui/templates/hamburger-menu.es6.js
@@ -1,8 +1,7 @@
 const bel = require('bel')
 
 module.exports = function () {
-    const isHidden = this.model.isOpen ? '' : 'is-hidden'
-    return bel`<nav class="hamburger-menu js-hamburger-menu ${isHidden}">
+    return bel`<nav class="hamburger-menu js-hamburger-menu is-hidden">
         <div class="hamburger-menu__bg"></div>
         <div class="hamburger-menu__content card padded">
             <h2 class="menu-title border--bottom hamburger-menu__content__more-options">
@@ -19,14 +18,14 @@ module.exports = function () {
                     </a>
                 </li>
                 <li>
-                    <a href="mailto:extension-feedback@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F"
+                    <a href="${renderFeedbackHref(this.model.domain)}"
                         class="menu-title">
                         Send feedback
                         <span>Got issues or suggestions? Let us know!</span>
                     </a>
                 </li>
                 <li>
-                    <a href="mailto:extension-brokensites@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%29%0A"
+                    <a href="${renderBrokenSiteHref(this.model.domain)}"
                         class="menu-title">
                         Report broken site
                         <span>If a site's not working, please tell us.</span>
@@ -35,4 +34,12 @@ module.exports = function () {
             </ul>
         </div>
     </nav>`
+}
+
+function renderFeedbackHref (domain) {
+    return `mailto:extension-feedback@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F%20%20%2E%0A%0AURL%20is%20${domain}`
+}
+
+function renderBrokenSiteHref (domain) {
+    return `mailto:extension-brokensites@duckduckgo.com?subject=Firefox%20Extension%20Broken%20Site%20Report&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0A1%2E%20Which%20website%20is%20broken%3F%20%28copy%20and%20paste%20the%20URL%29%0A%0A2%2E%20Describe%20the%20issue%2E%20%28What%27s%20breaking%20on%20the%20page%3F%20Attach%20a%20screenshot%20if%20possible%2E%29%0AURL%20is%20${domain}`
 }

--- a/js/ui/templates/hamburger-menu.es6.js
+++ b/js/ui/templates/hamburger-menu.es6.js
@@ -19,7 +19,7 @@ module.exports = function () {
                     </a>
                 </li>
                 <li>
-                    <a href="mailto:firefox@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you've%20encountered.%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F"
+                    <a href="mailto:firefox@duckduckgo.com?subject=Firefox%20Extension%20Feedback&body=Help%20us%20improve%20by%20sharing%20a%20little%20info%20about%20the%20issue%20you%27ve%20encountered%2E%0A%0ATell%20us%20which%20features%20or%20functionality%20your%20feedback%20refers%20to%2E%20What%20do%20you%20love%3F%20What%20isn%27t%20working%3F%20How%20could%20it%20be%20improved%3F"
                         class="menu-title">
                         Send feedback
                         <span>Got issues or suggestions? Let us know!</span>

--- a/js/ui/views/hamburger-menu.es6.js
+++ b/js/ui/views/hamburger-menu.es6.js
@@ -37,7 +37,7 @@ HamburgerMenu.prototype = $.extend({},
 
         _handleSiteUpdate: function (notif) {
               if (notif && notif.change.attribute === 'tab') {
-                  this.model.domain = notif.change.value.site.domain
+                  this.model.tabUrl = notif.change.value.url
                   this._rerender()
               }
         },

--- a/js/ui/views/hamburger-menu.es6.js
+++ b/js/ui/views/hamburger-menu.es6.js
@@ -12,7 +12,9 @@ function HamburgerMenu (ops) {
     this.bindEvents([
         [this.$close, 'click', this.closeMenu],
         [this.$optionslink, 'click', this.openOptionsPage],
-        [this.model.store.subscribe, 'action:search', this.handleAction]
+        [this.model.store.subscribe, 'action:search', this._handleAction],
+        [this.model.store.subscribe, 'change:site', this._handleSiteUpdate]
+
     ])
 }
 
@@ -20,7 +22,7 @@ HamburgerMenu.prototype = $.extend({},
     Parent.prototype,
     {
 
-        handleAction: function (notification) {
+        _handleAction: function (notification) {
             if (notification.action === 'burgerClick') this.openMenu()
         },
 
@@ -31,6 +33,13 @@ HamburgerMenu.prototype = $.extend({},
         closeMenu: function (e) {
             if (e) e.preventDefault()
             this.$el.addClass('is-hidden')
+        },
+
+        _handleSiteUpdate: function (notif) {
+              if (notif && notif.change.attribute === 'tab') {
+                  this.model.domain = notif.change.value.site.domain
+                  this._rerender()
+              }
         },
 
         openOptionsPage: function () {


### PR DESCRIPTION
replaces surveymonkey links in hamburger menu
Send Feedback and Report a Broken Site

This works fine in FF but:

##  this does not work in chrome

see:
https://stackoverflow.com/questions/3202613/mailto-link-not-working-in-chrome-extension-popup

- chrome will need a target attribute, but then this leaves an ugly open tab.
- solution there seems to be close the tab with a timer. ick.

## could improve readability
- with something like https://github.com/bendrucker/mailto-link 

## Steps to test this PR:

- open hamburger menu
- click on send feedback
- click on report a broken site

should open mail app, fill with subject and body text.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
