### PR TITLE
Site info in popup: streamline render cycle

### DIFF
--- a/css/popup.scss
+++ b/css/popup.scss
@@ -171,9 +171,10 @@ body {
 
     .site-info {
         position: absolute;
-        top: 40px;
+        top: 50px;
         left: 0;
         right: 0;
+        margin-top: 0;
 
         .default-list {
             padding-bottom: 0;
@@ -379,9 +380,10 @@ body {
 
     .top-blocked {
         position: absolute;
-        top: 390px;
+        top: 400px;
         left: 0;
         right: 0;
+        margin-top: 0;
 
         .top-blocked__list {
             padding-top: 10px;

--- a/css/popup.scss
+++ b/css/popup.scss
@@ -170,6 +170,10 @@ body {
     }
 
     .site-info {
+        position: absolute;
+        top: 40px;
+        left: 0;
+        right: 0;
 
         .default-list {
             padding-bottom: 0;
@@ -375,6 +379,8 @@ body {
     }
 
     .top-blocked {
+        position: absolute;
+        top: 395px;
 
         .top-blocked__list {
             padding-top: 10px;
@@ -401,6 +407,7 @@ body {
             position: relative;
             padding-top: 15px;
             padding-bottom: 15px;
+            top: initial;
 
             .site-info__domain {
                 margin-left: 20px;

--- a/css/popup.scss
+++ b/css/popup.scss
@@ -381,6 +381,8 @@ body {
     .top-blocked {
         position: absolute;
         top: 395px;
+        left: 0;
+        right: 0;
 
         .top-blocked__list {
             padding-top: 10px;

--- a/css/popup.scss
+++ b/css/popup.scss
@@ -168,8 +168,8 @@ body {
             }
         }
     }
-    
-    .site-info-placeholder {
+
+    .site-info--placeholder {
         height: 335px;
     }
 

--- a/css/popup.scss
+++ b/css/popup.scss
@@ -183,7 +183,7 @@ body {
         .site-info__protection {
             line-height: 1.4em;
             height: 1.2em;
-            display: inline-block;
+            display: block;
             max-width: $popup__width - 125;
             font-weight: bold;
             overflow: hidden;
@@ -220,13 +220,12 @@ body {
         }
 
         .site-info__toggle-container {
-            position: relative;
-            float: right;
-            padding-right: 40px;
+            position: absolute;
+            right: 20px;
+            top: 18px;
 
             .toggle-button {
                 position: absolute;
-                top: 3px;
                 right: 0;
             }
 
@@ -380,7 +379,7 @@ body {
 
     .top-blocked {
         position: absolute;
-        top: 395px;
+        top: 390px;
         left: 0;
         right: 0;
 

--- a/css/popup.scss
+++ b/css/popup.scss
@@ -168,6 +168,10 @@ body {
             }
         }
     }
+    
+    .site-info-placeholder {
+        height: 335px;
+    }
 
     .site-info {
         position: absolute;

--- a/html/popup.html
+++ b/html/popup.html
@@ -26,7 +26,7 @@
 
     <div id="popup-container"
          class="sliding-subview sliding-subview--root sliding-subview--has-fixed-header">
-         <div id="site-info-placeholder-container" class="site-info site-info-placeholder card"></div>
+         <div class="site-info site-info--placeholder card"></div>
     </div>
 
 <script src="../public/js/base.js" type="text/javascript"></script>

--- a/html/popup.html
+++ b/html/popup.html
@@ -26,6 +26,7 @@
 
     <div id="popup-container"
          class="sliding-subview sliding-subview--root sliding-subview--has-fixed-header">
+         <div id="site-info-placeholder-container" class="site-info site-info-placeholder card"></div>
     </div>
 
 <script src="../public/js/base.js" type="text/javascript"></script>

--- a/js/ui/views/site.es6.js
+++ b/js/ui/views/site.es6.js
@@ -8,10 +8,6 @@ function Site (ops) {
     this.pageView = ops.pageView
     this.template = ops.template
 
-    // render template for the first time here
-    // in default `this.model.isCalculatingSiteRating` state
-    Parent.call(this, ops)
-
     // cache 'body' selector
     this.$body = $('body')
 
@@ -19,11 +15,14 @@ function Site (ops) {
     this.model.getBackgroundTabData().then(() => {
         if (this.model.tab &&
            (this.model.tab.status === 'complete' || this.model.domain === 'new tab')) {
-            this.rerender()
+            // render template for the first time here
+            Parent.call(this, ops)
+            this._setup()
+
         } else {
             // the timeout helps buffer the re-render cycle during heavy
             // page loads with lots of trackers
-            this.rerender({skipSetup: true})
+            Parent.call(this, ops)
             setTimeout(() => this.rerender(), 750)
         }
     })
@@ -42,22 +41,6 @@ Site.prototype = $.extend({},
             w.close()
         },
 
-        rerender: function (ops) {
-            // console.log('[site view] rerender()')
-            ops = ops || {}
-            if (this.model && this.model.disabled) {
-                console.log('.addClass is-disabled')
-                this.$body.addClass('is-disabled')
-                this._rerender()
-                if (!ops.skipSetup) this._setup()
-            } else {
-                this.$body.removeClass('is-disabled');
-                this.unbindEvents()
-                this._rerender()
-                if (!ops.skipSetup) this._setup()
-            }
-        },
-
         // NOTE: after ._setup() is called this view listens for changes to
         // site model and re-renders every time model properties change
         _setup: function() {
@@ -73,6 +56,21 @@ Site.prototype = $.extend({},
                 [this.store.subscribe, 'change:site', this.rerender]
             ])
 
+        },
+
+        rerender: function () {
+            // console.log('[site view] rerender()')
+            if (this.model && this.model.disabled) {
+                console.log('.addClass is-disabled')
+                this.$body.addClass('is-disabled')
+                this._rerender()
+                this._setup()
+            } else {
+                this.$body.removeClass('is-disabled');
+                this.unbindEvents()
+                this._rerender()
+                this._setup()
+            }
         },
 
         _showAllTrackers: function () {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
Still not happy about the changes to render cycle I made earlier, so I made this PR to streamline the way it looks/feels when opening sites that have heavy on trackers. Right now (on a heavy site) you might see a flash of the "null" state sometimes between "calculating..." and the actual grade within the popup hero area. This fixes that.

## Steps to test this PR:
Pull this branch down, run cli cmd `$ npm run dev` and load a bunch of websites with a ton of trackers on them. The render cycle is smoother on heavy sites.

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
