### PR TITLE
CSS bugfix: shield icon cut off by 1px

### DIFF
--- a/css/popup.scss
+++ b/css/popup.scss
@@ -261,7 +261,7 @@ body {
         @mixin site_status_icons () {
             position: absolute;
             width: 17px;
-            height: 21px;
+            height: 22px;
             top: 10px;
             left: 20px;
         }
@@ -270,7 +270,6 @@ body {
             @include icon_display();
             @include site_status_icons();
             width: 15px;
-            height: 22px;
 
             &.is-secure, // default = secure, https
             &.is-upgraded {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:** 
-->

## Description:
The "shield" icon is cut off on the bottom by 1px, this is the fix.

## Steps to test this PR:
<!-- List steps to test it manually 
1. <STEP 1> 
-->

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
