### PR TITLE
Screenshot testing & bg process console output: surface perf data

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -58,7 +58,11 @@ class Tab {
         this.status = tabData.status
         this.site = new Site(utils.extractHostFromURL(tabData.url))
         this.statusCode // statusCode is set when headers are recieved in tabManager.js
-
+        this.stopwatch = {
+            begin: Date.now(),
+            end: null,
+            completeMs: null
+        }
         // set the new tab icon to the dax logo
         chrome.browserAction.setIcon({path: 'img/icon_48.png', tabId: tabData.tabId})
     };
@@ -147,6 +151,12 @@ class Tab {
             const downgrade = this.url.replace(/^https:\/\//i, 'http://')
             chrome.tabs.update(this.id, { url: downgrade })
         }
+    }
+
+    endStopwatch () {
+        this.stopwatch.end = Date.now()
+        this.stopwatch.completeMs = (this.stopwatch.end - this.stopwatch.begin)
+        console.log(`tab.status: complete. site took ${this.stopwatch.completeMs/1000} seconds to load.`)
     }
 }
 

--- a/js/tabManager.js
+++ b/js/tabManager.js
@@ -108,6 +108,8 @@ chrome.tabs.onUpdated.addListener( (id, info) => {
                     Companies.incrementTotalPages()
                     tab.site.didIncrementCompaniesData = true
                 }
+
+                if (tab.statusCode === 200) tab.endStopwatch()
             }
         }
     }

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,7 @@
       <a href="/test/html/unitTests.html">
              <input type="button" value="Run Unit Tests" />
       </a>
-      
+
 
       <h2>Manual tests</h2>
 
@@ -22,14 +22,14 @@
 
       <h2>Debug a single site</h2>
       <form action="/test/html/debugSite.html">
-        http://<input type="text" name="site" value="site to debug"/>
+        http://<input type="text" name="site" placeholder="site to debug"/>
         <input type="submit" value="Run" />
       </form>
 
       <h2>Screenshot tests</h2>
 
       <form action="/test/html/screenshots.html">
-        <input type="text" name="numberToTest" value="# sites to test"/>
+        <input type="text" name="numberToTest" placeholder="# sites to test"/>
         <input type="submit" value="Run" />
         <input type="checkbox" name="screenshots" value="true" checked>screenshots</input>
         <input type="checkbox" name="random" value="true">random</input>

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -5,7 +5,7 @@ function cleanUpTabs(tabs) {
     tabs.forEach((tab) => chrome.tabs.remove(tab.id));
 }
 
-/* Wait for a tab to finish loading and return the chrome tab object 
+/* Wait for a tab to finish loading and return the chrome tab object
  * getLoadedTab(<url>).then( do stuff );
  */
 
@@ -31,7 +31,7 @@ function getLoadedTabById(id, startTime, timeout, delay, delayStart) {
     return new Promise((resolve) => {
         chrome.tabs.get(id, (tab) => {
                 if (tab && tab.status === 'complete') {
-                   
+
                     if (delay && delayStart) {
                         if ((Date.now() - delayStart) > delay) {
                             resolve(tab);
@@ -104,4 +104,12 @@ function takeScreenshot() {
 function resetSettings(settingState) {
     bkg.settings.updateSetting('trackerBlockingEnabled', settingState)
     bkg.settings.updateSetting('httpsEverywhereEnabled', settingState)
+}
+
+function clearCache () {
+    return new Promise((resolve) => {
+        const millisecondsPerWeek = 1000 * 60 * 60 * 24 * 7
+        const oneWeek = (new Date()).getTime() - millisecondsPerWeek
+        chrome.browsingData.remove({'since': oneWeek}, {'cache': true}, () => resolve())
+    })
 }

--- a/test/tests/screenshots.js
+++ b/test/tests/screenshots.js
@@ -30,7 +30,9 @@ function buildSummary() {
     let table = '<table><tr><td><b>Tracker Blocking ON</b></td><td><b>Tracker Blocking OFF</b></td></tr>';
 
     screenshots.forEach((x) => {
-        table += '<tr><td>Site Score: ' + x.score + ' <a href="' + x.url + '">' + x.url + '</a></td><td></tr>';
+        table += '<tr><td><a href="' + x.url + '">' + x.url + '</a> - <b>Site Score:</b> ' + JSON.stringify(x.score) + '</td><td></td></tr>';
+        table += '<tr><td>Tab took <b>' + x.enabledOnComplete +'</b> to complete.</td>'
+        table += '<td>Tab took <b>' + x.disabledOnComplete +'</b> to complete.</td></tr>'
         table += '<tr><td><img id="on" src="' + x.on + '" /></td>';
         table += '<td><img id="off" src="' + x.off + '" /></td></tr>';
     });
@@ -122,13 +124,16 @@ function runTest(url) {
 
         chrome.tabs.create({url}, (t) => {
 
-            getLoadedTabById(t.id, blockingOnStartTime, 8000, 1000).then((tab) => {
+            getLoadedTabById(t.id, blockingOnStartTime, 9000, 3000).then((tab) => {
                 let blocking = bkg.settings.getSetting('trackerBlockingEnabled')
                 let tabObj = bkg.tabManager.get({'tabId': tab.id});
 
                 if (blocking) {
-                    newScreenshots.scoreObj = tabObj.site.score;
+                    newScreenshots.scoreObj = tabObj.site.score
                     newScreenshots.score = tabObj.site.score.get()
+                    newScreenshots.enabledOnComplete = tabObj.stopwatch.completeMs/1000 + ' seconds'
+                } else {
+                    newScreenshots.disabledOnComplete = tabObj.stopwatch.completeMs/1000 + ' seconds'
                 }
 
                 takeScreenshot().then((image) => {

--- a/test/tests/screenshots.js
+++ b/test/tests/screenshots.js
@@ -65,17 +65,17 @@ function processSite(url) {
     resetSettings(true);
 
     // run test with tracker blocking and https
-    runTest(url).then(() => {
+    clearCache().then(runTest(url).then(() => {
 
         // turn tracker blocking off
         resetSettings(false);
 
-        runTest(url).then(() => {
+        clearCache().then(runTest(url).then(() => {
             screenshots.push(newScreenshots);
             buildSummary();
             return;
-        });
-    });
+        }));
+    }));
 }
 
 /*
@@ -107,7 +107,6 @@ function processTopSites() {
         resetSettings(false);
 
         runTest(url).then(() => {
-
             screenshots.push(newScreenshots)
             processTopSites();
         });
@@ -115,7 +114,7 @@ function processTopSites() {
 }
 
 /*
- * Navigate to a url, take a screenshot and record the page load time
+ * Navigate to a url, take a screenshot and record tab oncomplete time
  */
 function runTest(url) {
     return new Promise((resolve) => {


### PR DESCRIPTION
**Reviewer:**
@jdorweiler 

## Description:
Adding perf data to our screenshot testing, both with and without extension "on" for site. Also added perf data to background process console output as well.

Added test util fn to clear cache before each page load during screenshot tests so that perf data is not corrupted by latency due to caching

While I was in there, also updated site score display as well.

![perf-data](https://user-images.githubusercontent.com/1278969/33361717-2ffc87fa-d48e-11e7-9900-df23ede63c6d.png)

## Steps to test this PR:
1. Pull this branch down via cli, run $ npm run dev to build
2. Reload extension in browser
3. Navigate to `/test/index.html`. Put a number into "Screenshot tests" input box, click each of the checkboxes, click `Run` button.

## Automated tests:
- [ ] Unit tests
- [X] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
