### PR TITLE
bugfix: break easylist loop on match

### DIFF
--- a/js/trackers.js
+++ b/js/trackers.js
@@ -102,6 +102,7 @@ require.scopes.trackers = (function() {
     function checkEasylists(url, siteDomain, request){
         let toBlock = false
         constants.easylists.some((listName) => {
+
             let match
             // lists can take a second or two to load so check that the parsed data exists
             if (easylists[listName].isLoaded) {
@@ -112,6 +113,7 @@ require.scopes.trackers = (function() {
             if (match) {
                 toBlock = getTrackerDetails(url, listName)
                 toBlock.block = true
+                return toBlock
             }
         })
 


### PR DESCRIPTION
## Description:
The trackers module wasn't breaking the easylist loop on finding a match which impacts perf.

## Steps to test this PR:
1. pull this branch down and install manually, open debugger on background process
2. add a console message just before the `return toBlock` added in this PR
3. observe that easylist loop is breaking on matches now

## Automated tests:
- [ ] Unit tests
- [ ] Integration tests

###### Reviewer Checklist:
- [ ] **Ensure the PR solves the problem**
- [ ] **Review every line of code**
- [ ] **Ensure the PR does no harm by testing the changes thoroughly**
- [ ] **Get help if you're uncomfortable with any of the above!**
- [ ] Determine if there are any quick wins that improve the implementation


###### PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications 
